### PR TITLE
Fix for #88

### DIFF
--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -164,6 +164,8 @@ define([
           var element;
           var offset;
           var value;
+          var isProperty;
+          var propertyName;
 
           blocks.eachRight(this._expressions, function updateExpression(expression) {
             element = expression.element;
@@ -185,9 +187,16 @@ define([
             offset = expression.length - value.length;
             expression.length = value.length;
 
+            isProperty = dom.props[expression.attr];
+            propertyName = expression.attr ? dom.propFix[expression.attr.toLowerCase()] || expression.attr : null;
+
             if (element) {
               if (expression.attr) {
-                element.setAttribute(expression.attr, Expression.GetValue(context, null, expression.entire));
+                if(isProperty) {
+                  element[propertyName] = Expression.GetValue(context, null, expression.entire);
+                } else {
+                  element.setAttribute(expression.attr, Expression.GetValue(context, null, expression.entire));
+                }
               } else {
                 if (element.nextSibling) {
                   element = element.nextSibling;


### PR DESCRIPTION
Added check for properties to (the properties from /query/dom.props).

When you look onto the element with the inspector of your browser, the value attribute wil still be the expression.
That behaviour could be confusing for developers, maybe we should add a comment or something like a ``data-bl-{{attributeName}}`` attribute like so:
```javascript
blocks.query({val: blocks.observable('Some Value')});
```
```html
<!-- 1:blocks value: "Some Value"  -->
<input value="{{val}}" data-bl-value="Some Value" data-id="1" />
```

Updating the original attribute is not recommend as it can cause missbehaving in some browsers.

What do you think ?

Also 2 derps :sweat_smile: with the github client (Now I'll rollback to the commandline version of git).

