### PR TITLE
Added garbadge collection for observables._expressions. FIxes #90

### DIFF
--- a/src/query/ElementsData.js
+++ b/src/query/ElementsData.js
@@ -74,7 +74,8 @@
           // if element is not defined then treat it as expression
           if (!element) {
             currentData = data[id] = {
-              id: id
+              id: id,
+              observables: {}
             };
           } else {
             currentData = data[id] = {
@@ -114,10 +115,20 @@
         if (currentData && (!currentData.haveData || force)) {
           blocks.each(currentData.observables, function (value) {
             for (var i = 0; i < value._elements.length; i++) {
-              if (value._elements[i].elementId == data.id) {
+              if (value._elements[i].elementId == currentData.id) {
                 value._elements.splice(i, 1);
                 i--;
               }
+            }
+
+            if (value._expressionKeys[currentData.id]) {
+              for (i = 0; i < value._expressions.length; i++) {
+                if (value._expressions[i].elementId == currentData.id) {
+                  value._expressions.splice(i, 1);
+                  i--;
+                }
+              }
+              value._expressionKeys[currentData.id] = null;
             }
           });
           data[id] = undefined;

--- a/src/query/Expression.js
+++ b/src/query/Expression.js
@@ -145,6 +145,8 @@ define([
               observable._expressionKeys[elementData.id] = true;
               observable._expressions.push(expressionObj);
             }
+
+            elementData.observables[observable.__id__ + (attributeName || 'expression') + '[' + expression + ']'] = observable;
           });
         }
         if (!attributeName) {


### PR DESCRIPTION
Observables used in expressions will now get stored in 
``elementData.observables`` for garbage collection, before only observables in data-query methods  got stored there.

``ElementData.clear`` now also cleans up the ``javascript observables._expression`` and ``javascript observables._expressionKeys`` objects/arrays.
Fixes #90.

Also corrected a [typo](https://github.com/Kanaye/jsblocks/blob/7db227b583dc164422c183d58ca3bdc386f50788/src/query/ElementsData.js#L126) (Or at least i think it's a typo cause i could not find any case where data has an id property. Correct me if I'm wrong!)

Say if you don't like something with my solution or had something other with the ``elementData.observables`` array in mind.

Have a nice day.