### PR TITLE
Added check for __Class__ in blocks.observable. Closes #100.

### DIFF
--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -71,7 +71,7 @@ define([
       observable._chunkManager = new ChunkManager(observable);
     } else if (blocks.isFunction(initialValue)) {
       observable._dependencyType = 1; // Function dependecy
-    } else if (initialValue && blocks.isFunction(initialValue.get) && blocks.isFunction(initialValue.set)) {
+    } else if (initialValue && !initialValue.__Class__ && blocks.isFunction(initialValue.get) && blocks.isFunction(initialValue.set)) {
       observable._dependencyType = 2; // Custom object
     }
 


### PR DESCRIPTION
Observables check for ``set`` and ``get``-functions on the argument and then mark it as a dependency observables.
Models implement that functions but not as expected for dependency-observables.