### PR TITLE
Fixed bug with server side attribute expression.

### DIFF
--- a/src/node/overrides.js
+++ b/src/node/overrides.js
@@ -84,13 +84,14 @@ define([
     
     if (regExResult) {
       elementData = ElementsData.byId(regExResult[1]);
-      if (elementData) {
-        if (expressionData.attributeName) {
-          server.data[elementData.id + expressionData.attributeName] =  entireExpression.text;
-        } else {
-          server.data[elementData.id] = '{{' + expressionData.expression + '}}';
-        }
-      }  
+    }
+
+    if (elementData) {
+      if (expressionData.attributeName) {
+        server.data[elementData.id + expressionData.attributeName] =  entireExpression.text;
+      } else {
+        server.data[elementData.id] = '{{' + expressionData.expression + '}}';
+      }
     }
 
     return value;

--- a/src/query/VirtualElement.js
+++ b/src/query/VirtualElement.js
@@ -625,6 +625,11 @@ define([
       var expression;
 
       blocks.each(this._attributes, function (attributeValue, attributeName) {
+        if(!attributeValue) {
+          // In Serverside rendering, some attributes will be set to null in some cases
+          return;
+        }
+
         if (!each && serverData && serverData[dataId + attributeName]) {
           expression = Expression.Create(serverData[dataId + attributeName], attributeName);
         } else {


### PR DESCRIPTION
Server side attribute expressions did not get transfered to the client, 
so these expressions did not get updated clientside.

To be more clear an example:
```html
<input type="text" data-query="myObservable" />
 <!-- when updateing the first input this expression got updated -->
{{myObservable}}

<!-- this one did not -->
<input type="text" value="{{myObservable} "/>
```

Found that while trying to find a solution for #40.