### PR TITLE
Now extending prototypes of 'Route' and 'Router'.

### DIFF
--- a/src/modules/Router.js
+++ b/src/modules/Router.js
@@ -44,7 +44,7 @@
     return route;
   };
 
-  Route.prototype = {
+  blocks.extend(Route.prototype, {
     wildcard: function () {
       var wildcard = this._wildcard;
       var wildcards = blocks.flatten(blocks.toArray(arguments));
@@ -111,7 +111,7 @@
         metadata[nameOrObject] = value;
       }
     }
-  };
+  });
 
   function Router() {
     this._currentRoute = {};
@@ -132,7 +132,7 @@
     return route;
   };
 
-  Router.prototype = {
+  blocks.extend(Router.prototype, {
     registerRoute: function (route, parentRoute) {
       route = Route(route);
       parentRoute = parentRoute ? Route(this._routes[Route(parentRoute).toString()].route) : Route(undefined);
@@ -381,7 +381,7 @@
         }
       });
     }
-  };
+  });
 
   return Router;
 });


### PR DESCRIPTION
Extending prototypes of 'Router' and 'Route' instead of overwriting it initialy.
When overwritten the prototype, 'blocks.clone' would detect that the constructor is
'Object' and not call the right constructor.
Which leads to bugs in 'Application.View()'.