### PR TITLE
Added update function to options-query fixes #74.

### DIFF
--- a/src/query/Expression.js
+++ b/src/query/Expression.js
@@ -89,7 +89,13 @@ define([
 
       if (length == 1) {
         if (nodeWise) {
-          value[0] = Expression.Execute(context, elementData, expression[0], expression, type);
+          lastNodeIndex = expression.nodeLength;
+          tempValue = Expression.Execute(context, elementData, expression[0], expression, type);
+
+          if ((expression.nodeLength - lastNodeIndex) == 2) {
+            value[expression.nodeLength - 2] = null;
+          }
+          value[expression.nodeLength - 1] = tempValue; 
         } else {
           value = Expression.Execute(context, elementData, expression[0], expression, type);
         }

--- a/src/query/VirtualElement.js
+++ b/src/query/VirtualElement.js
@@ -671,14 +671,14 @@ define([
         value = Expression.GetValue(context, elementData, expression);
         attributeName = expression.attributeName;
         if ((attributes && attributes[attributeName] !== value) || !attributes) {
-          if (isVirtual) {
-            if (this._state) {
-              this._state.attributes[attributeName] = value;
-            } else {
-              this._attributes[attributeName] = value;
-            }
-          } else {
+          if (isVirtual && !this._state) {
+            this._attributes[attributeName] = value;
+          } else if (!isVirtual) {
             dom.attr(this._el, attributeName, value);
+          }
+
+          if (this._state) {
+            this._state.attributes[attributeName] = value;
           }
         }
       }

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -350,7 +350,6 @@ define([
         reset: function (array) {
           if (arguments.length === 0) {
             this.removeAll();
-            this.update();
             return this;
           }
 

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -65,6 +65,10 @@ define([
     observable._elementKeys = {};
     observable._elements = [];
 
+    observable._getValue = function () {
+      return getObservableValue(observable);
+    };
+
     if (blocks.isArray(initialValue)) {
       blocks.extend(observable, blocks.observable.fn.array);
       observable._indexes = [];

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -171,6 +171,8 @@ define([
           var isProperty;
           var propertyName;
 
+          Observer.startObserving();
+
           blocks.eachRight(this._expressions, function updateExpression(expression) {
             element = expression.element;
             context = expression.context;
@@ -245,6 +247,8 @@ define([
           blocks.each(this._indexes, function updateIndex(observable, index) {
             observable(index);
           });
+
+          Observer.stopObserving();
 
           return this;
         },

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -342,6 +342,7 @@ define([
         reset: function (array) {
           if (arguments.length === 0) {
             this.removeAll();
+            this.update();
             return this;
           }
 
@@ -380,6 +381,8 @@ define([
           }
 
           this.__value__ = array;
+
+          this.update();
 
           Events.trigger(this, 'remove', {
             type: 'remove',

--- a/test/spec/query/queries.js
+++ b/test/spec/query/queries.js
@@ -832,6 +832,126 @@
       expect($('#testElement').children().eq(2)).toHaveText('Mihaela');
       expect($('#testElement').children().eq(2)).toHaveValue('2');
     });
+
+    it('updates correctly text and value after reset', function () {
+      setQuery('options(items, options)');
+
+      var items = blocks.observable([
+        {
+          Id: 0,
+          Name: blocks.observable('Joscha')
+        },
+        {
+          Id: 1,
+          Name: blocks.observable('Unknown')
+        }]
+      );
+
+      query({
+        items: items,
+        options: {
+          text: 'Name',
+          value: 'Id'
+        }
+      });
+
+      expect($('#testElement').children().eq(0)).toHaveText('Joscha');
+      expect($('#testElement').children().eq(0)).toHaveValue('0');
+      expect($('#testElement').children().eq(1)).toHaveText('Unknown');
+      expect($('#testElement').children().eq(1)).toHaveValue('1');
+
+      items.reset([{
+        Id: 0,
+        Name: blocks.observable('Someone else')
+      }]);
+
+      expect($('#testElement').children.length).toBe(2);
+
+      expect($('#testElement').children().eq(0)).toHaveText('Someone else');
+      expect($('#testElement').children().eq(0)).toHaveValue('0');
+
+    });
+
+    it('updates selected correctly after reset', function () {
+      setQuery('options(items, options).val(val)');
+
+      var items = blocks.observable([
+        {
+          Id: 0,
+          Name: blocks.observable('Joscha')
+        },
+        {
+          Id: 1,
+          Name: blocks.observable('Unknown')
+        }]
+      );
+
+      var val = blocks.observable('1');
+      query({
+        val: val,
+        items: items,
+        options: {
+          text: 'Name',
+          value: 'Id'
+        }
+      });
+
+      expect($('#testElement').children().eq(0)).toHaveText('Joscha');
+      expect($('#testElement').children().eq(0)).toHaveValue('0');
+      expect($('#testElement').children().eq(1)).toHaveText('Unknown');
+      expect($('#testElement').children().eq(1)).toHaveValue('1');
+
+      items.reset([{
+        Id: 0,
+        Name: blocks.observable('Someone else')
+      }]);
+
+      expect(val()).toBe('0');
+
+      expect($('#testElement').children().eq(0)).toHaveText('Someone else');
+      expect($('#testElement').children().eq(0)).toHaveValue('0');
+    });
+
+    it('updates selected correctly after reset to the caption', function () {
+      setQuery('options(items, options).val(val)');
+
+      var items = blocks.observable([
+        {
+          Id: 0,
+          Name: blocks.observable('Joscha')
+        },
+        {
+          Id: 1,
+          Name: blocks.observable('Unknown')
+        }]
+      );
+
+      var val = blocks.observable('1');
+      query({
+        val: val,
+        items: items,
+        options: {
+          caption: 'select something',
+          text: 'Name',
+          value: 'Id'
+        }
+      });
+
+      expect($('#testElement').children().eq(1)).toHaveText('Joscha');
+      expect($('#testElement').children().eq(1)).toHaveValue('0');
+      expect($('#testElement').children().eq(2)).toHaveText('Unknown');
+      expect($('#testElement').children().eq(2)).toHaveValue('1');
+
+      items.reset([{
+        Id: 0,
+        Name: blocks.observable('Someone else')
+      }]);
+
+      expect(val()).toBe('select something');
+
+      expect($('#testElement').children().eq(0)).toHaveText('select something');
+      expect($('#testElement').children().eq(0)).toHaveValue('select something');
+    });
   });
 
   describe('blocks.queries.template', function () {


### PR DESCRIPTION
Initial problem with not updating attributes in this edgecase is fixed through updating the ``_state`` property of an VirtualElement as long as the property exsits (and changes).

Added call to ``observable.update()`` in array-oservables ``reset()`` function.
Did not find a case where this could break something, correct me if I'm wrong.

Added a function called ``observable._getValue()`` which just returns the value but does not subscribe it to the ``Observer``. I need this for the ``update`` function of the ``options`` data-query.

Also ``observable.update`` now _not_ subscribes observables or to be more correct it creates and drops a new Observer stack.
I couldn't find a case where it breaks something as the call that causes the subsciption is caused by and on already subscribed elements.

Fixed a bug with the new ``Expression.NodeWise`` rendering that caused some wrong updates in the select.

Added the ``update``-function to the ``options``-data-query and tests for it which causes following behaviour:

On update(reset, remove, ...) of the collection:
* if the selected value is in the collection this value is used (no action will be performed).
* if the selected value is *not* in the collection but there is an option with ``data-role="header"`` (=caption in the queries options)  this option is used.
* if the selected value is *not* in the collection and there is *no* caption/``data-role="header"``-option the value is set to the first item of the collection.

Hope I've been clear enough. Ask questions if you have some :smile:.

Fixes #74.