### PR TITLE
Moved 'View._bindContext' to src/mv/bindContext.js.

### DIFF
--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -6,8 +6,9 @@ define([
   './Model',
   './Collection',
   './View',
-  './Property'
-], function (blocks, clonePrototype, Router, History, Model, Collection, View, Property) {
+  './Property',
+  './bindContext'
+], function (blocks, clonePrototype, Router, History, Model, Collection, View, Property, bindContext) {
 
   var application;
   blocks.Application = function (options) {
@@ -269,7 +270,7 @@ define([
 
     extend: function (obj) {
       blocks.extend(this, obj);
-      clonePrototype(obj, this);
+      bindContext(this, obj);
       return this;
     },
 

--- a/src/mvc/View.js
+++ b/src/mvc/View.js
@@ -1,15 +1,16 @@
 define([
   '../core',
   '../modules/ajax',
-  '../modules/Events'
-], function (blocks, ajax, Events) {
+  '../modules/Events',
+  './bindContext'
+], function (blocks, ajax, Events, bindContext) {
   /**
    * @namespace View
    */
   function View(application, parentView) {
     var _this = this;
 
-    this._bindContext();
+    bindContext(this);
     this._views = [];
     this._application = application;
     this._parentView = parentView || null;
@@ -147,21 +148,6 @@ define([
 
     navigateTo: function (view, params) {
       this._application.navigateTo(view, params);
-    },
-
-    _bindContext: function () {
-      var key;
-      var value;
-
-      for (key in this) {
-        value = this[key];
-
-        if (blocks.isObservable(value)) {
-          value.__context__ = this;
-        } else if (blocks.isFunction(value)) {
-          this[key] = blocks.bind(value, this);
-        }
-      }
     },
 
     _tryInitialize: function (isActive) {

--- a/src/mvc/bindContext.js
+++ b/src/mvc/bindContext.js
@@ -1,0 +1,24 @@
+define([
+	'../core'
+], function (blocks) {
+	function bindContext (context, object) {
+		var key;
+		var value;
+		
+		if (!object) {
+			object = context;
+		}
+
+		for (key in object) {
+			value = object[key];
+
+			if (blocks.isObservable(value)) {
+				context[key].__context__ = context;
+			} else if (blocks.isFunction(value)) {
+				context[key] = blocks.bind(value, context);
+			}
+
+		}
+	}
+	return bindContext;
+});


### PR DESCRIPTION
Replaced 'clonePrototype' in 'Application.extend' with 'bindContext'.

Before observables lose there relation to the original observable.
To reproduce this:
* Clone the shopping-example.
* Replace the wrong version from bower with the 0.3.4.
* Start the app (server siede rendering does not matter)
* Try out the search.
