### PR TITLE
Fixed some issues with template data-query.

### DIFF
--- a/src/node/overrides.js
+++ b/src/node/overrides.js
@@ -115,7 +115,13 @@ define([
   blocks.queries.template.preprocess = function (domQuery, html, value) {
     if (VirtualElement.Is(html)) {
       html = html.html();
+    } else if (blocks.isObject(html)) {
+      html =  GLOBAL[html.rawValue] && GLOBAL[html.rawValue].html();
     }
+    if (blocks.isObject(value) && value.parameterName) {
+      value = value.rawValue;
+    }
+
     if (html) {
       if (value) {
         blocks.queries['with'].preprocess.call(this, domQuery, value, '$template');

--- a/src/query/DomQuery.js
+++ b/src/query/DomQuery.js
@@ -179,6 +179,7 @@ define([
           currentParameter.value = blocks.unwrapObservable(currentParameter.rawValue);
 
           if (method.passDetailValues) {
+            currentParameter.parameterName = parameter;
             currentParameter.isObservable = blocks.isObservable(currentParameter.rawValue);
             currentParameter.containsObservable = Observer.currentObservables().length > lastObservablesLength;
             lastObservablesLength = Observer.currentObservables().length;

--- a/src/query/queries.js
+++ b/src/query/queries.js
@@ -91,17 +91,22 @@ define([
      */
     template: {
       passDomQuery: true,
-      passRawValues: true,
+      passDetailValues: true,
 
       preprocess: function (domQuery, template, value) {
         var serverData = domQuery._serverData;
         var html;
+        var templateName = template.parameterName;
+        template = template.rawValue;
+        if (value) {
+          value = value.rawValue;  
+        }
 
         template = blocks.$unwrap(template);
         if (blocks.isElement(template)) {
           html = template.innerHTML;
         } else {
-          html = document.getElementById(template);
+          html = document.getElementById( blocks.isString(template) ? template : templateName);
           if (html) {
             html = html.innerHTML;
           } else {

--- a/test/spec/query/queries.js
+++ b/test/spec/query/queries.js
@@ -1031,6 +1031,20 @@
       expect($('#testElement')).toHaveHtml('overrides');
     });
 
+    it('grabs the script when widow does not contain the script object', function () {
+      setTemplate('This is evil!');
+      
+      $('#testTemplate').attr('id', 'alert');
+      
+      setQuery('template(alert)');
+      query();
+
+      expect($('#testElement')).toHaveHtml('This is evil!');
+
+      $('#alert').attr('id', 'testTemplate');
+
+    });
+
     it('does not override content when template value is not defined', function () {
       $('#testElement').html('some content');
 


### PR DESCRIPTION
Fixes all issues found in astoilkov/jsblocks-shopping-example#6:
* Bug with 'sidebar'-named Template in Firefox. When the template is an object but nor an element blocks will now try to get elment with the ID passed.
* Implemented server-side rendering of the ``template`` query when passed with a string as id.

Closes astoilkov/jsblocks-shopping-example#6.