### PR TITLE
Added Blocks.middleware...

### DIFF
--- a/src/modules/Router.js
+++ b/src/modules/Router.js
@@ -116,6 +116,7 @@
   function Router() {
     this._currentRoute = {};
     this._routes = {};
+    this._baseUrl = '';
   }
 
   blocks.core.Router = Router;
@@ -170,6 +171,10 @@
         }
       });
 
+      if (this._baseUrl) {
+        result = this._baseUrl + result;
+      }
+
       return result;
     },
 
@@ -180,6 +185,10 @@
 
       url = decodeURI(url);
 
+      if (this._baseUrl && url.startsWith(this._baseUrl)) {
+        url = url.substr(this._baseUrl.length, url.length);
+      }
+
       blocks.each(this._routes, function (routeMetadata) {
         blocks.each(routeMetadata.regExCollection, function (regEx) {
           if (regEx.regEx.test(url)) {
@@ -189,7 +198,7 @@
                 id: routeMetadata.route._routeString,
                 params: getUrlParams(routeMetadata, regEx.params, matches)
               });
-              routeMetadata  = routeMetadata.parent;
+              routeMetadata = routeMetadata.parent;
             }
             return false;
           }
@@ -380,6 +389,17 @@
           });
         }
       });
+    },
+    _setBaseUrl: function (url) {
+      if (blocks.isString(url)) {
+        if (!url.endsWith('/')) {
+          url += '/';
+        }
+        if(url.startsWith('/')) {
+          url = url.substr(1, url.length);
+        }
+        this._baseUrl = url;
+      }
     }
   };
 

--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -286,6 +286,11 @@ define([
       if (!this._started) {
         this._started = true;
         this._serverData = window.__blocksServerData__;
+        
+        if (this._serverData && this._serverData.baseUrl) {
+          this._router._setBaseUrl(this._serverData.baseUrl);
+        }
+        
         this._createViews();
         blocks.domReady(blocks.bind(this._ready, this, element));
       }

--- a/src/node/BrowserEnv.js
+++ b/src/node/BrowserEnv.js
@@ -28,7 +28,11 @@ define([
         location[name] = props[name];
       });
     },
-
+    setBaseUrl: function (url) {
+      if (url) {
+        this._env.__baseUrl__ = url;
+      }
+    },
     addElementsById: function (elementsById) {
       var env = this._env;
       env.document.__elementsById__ = elementsById;

--- a/src/node/Middleware.js
+++ b/src/node/Middleware.js
@@ -39,6 +39,7 @@ define([
           next();
         } else {
           res.send(contents);
+          return;
         }
       });
     },
@@ -100,6 +101,7 @@ define([
     _createBrowserEnv: function (req, server) {
       var browserEnv = BrowserEnv.Create();
 
+      browserEnv.setBaseUrl(req.baseUrl);
       browserEnv.fillLocation(this._getLocation(req));
       browserEnv.addElementsById(this._elementsById);
       browserEnv.fillServer(server);
@@ -108,7 +110,7 @@ define([
     },
 
     _getLocation: function (req) {
-      return req.protocol + '://' + req.get('host') + req.url;
+      return req.protocol + '://' + req.get('host') + req.originalUrl;
     }
   };
 });

--- a/src/node/Middleware.js
+++ b/src/node/Middleware.js
@@ -29,7 +29,8 @@ define([
   Middleware.Defaults = {
     static: 'app',
     blocksPath: 'node_modues/blocks/blocks.js',
-    cache: true
+    cache: true,
+    baseTag: false
   };
 
   Middleware.prototype = {

--- a/src/node/createBrowserEnvObject.js
+++ b/src/node/createBrowserEnvObject.js
@@ -31,6 +31,7 @@ define(function () {
     var timeoutId = 0;
     var windowObj = {
       __mock__: true,
+      __baseUrl__: '',
 
       console: createConsoleMock(),
 

--- a/src/node/methods.js
+++ b/src/node/methods.js
@@ -1,9 +1,32 @@
 define([
   '../core',
   './Server',
-], function (blocks, Server) {
+  './Middleware'
+], function (blocks, Server, Middleware) {
   blocks.server = function (options) {
     return new Server(options);
+  };
+
+  blocks.middleware = function (options) {
+  	var express = require('express');
+  	var path = require('path');
+  	// the real middleware
+  	var middleware;
+  	// array of middlewares to return
+  	var middlewares = [];
+
+  	options = blocks.extend({}, Middleware.Defaults, options);
+  	middleware = new Middleware(options);
+
+  	// express.static is required as the frontend app needs it's files
+  	middlewares.push(express.static(path.resolve(options.static), {
+  		index: false
+  	}));
+
+  	middlewares.push(blocks.bind(middleware.tryServePage, middleware));
+
+  	// returning array of express middlewares that express will call in that order
+  	return middlewares;
   };
 
   blocks.static = function (options) {

--- a/src/node/methods.js
+++ b/src/node/methods.js
@@ -7,29 +7,43 @@ define([
     return new Server(options);
   };
 
-  blocks.middleware = function (options) {
-  	var express = require('express');
-  	var path = require('path');
-  	// the real middleware
-  	var middleware;
-  	// array of middlewares to return
-  	var middlewares = [];
+  blocks.static = function (options) {
 
-  	options = blocks.extend({}, Middleware.Defaults, options);
-  	middleware = new Middleware(options);
-
-  	// express.static is required as the frontend app needs it's files
-  	middlewares.push(express.static(path.resolve(options.static), {
-  		index: false
-  	}));
-
-  	middlewares.push(blocks.bind(middleware.tryServePage, middleware));
-
-  	// returning array of express middlewares that express will call in that order
-  	return middlewares;
   };
 
-  blocks.static = function (options) {
-    
+  blocks.middleware = function (options) {
+	var express = require('express');
+	var path = require('path');
+	// the real middleware
+	var middleware;
+	// array of middlewares to return
+	var middlewares = [];
+
+	var defaults = {
+		// Should the files in static get delivered 
+		deliverStatics: true,
+		baseTag: true
+	};
+
+	if (blocks.isString(options)) {
+		options = {
+			static: options
+		};
+	}
+
+	options = blocks.extend({}, Middleware.Defaults, defaults, options);
+	middleware = new Middleware(options);
+
+	if (options.deliverStatics) {
+		// express.static is required as the frontend app needs it's files
+		middlewares.push(express.static(path.resolve(options.static), {
+			index: false
+		}));
+	}
+
+	middlewares.push(blocks.bind(middleware.tryServePage, middleware));
+
+	// returning array of express middlewares that express will call in that order
+	return middlewares;
   };
 });

--- a/src/node/overrides.js
+++ b/src/node/overrides.js
@@ -198,4 +198,14 @@ define([
       this.callSuccess(contents);
     }
   };
+
+  var blocksApplication = blocks.Application;
+
+  blocks.Application = function (options) {
+    var app = blocksApplication(options);
+    app._router._setBaseUrl(window.__baseUrl__);
+    server.data.baseUrl = window.__baseUrl__;
+    return app;
+  };
+
 });

--- a/src/node/overrides.js
+++ b/src/node/overrides.js
@@ -49,6 +49,9 @@ define([
     server.await(function () {
       if (head) {
         head.children().splice(0, 0, getServerDataScript());
+        if (server.options.baseTag) {
+          head.children().splice(0, 0, getBaseTag());
+        }
       }
       server.rendered = root.renderChildren();
     });
@@ -69,6 +72,11 @@ define([
     });
 
     return result;
+  }
+
+  function getBaseTag() {
+    var baseUrl = window.location.protocol + '//' + window.location.host +  window.__baseUrl__ + '/';
+    return VirtualElement('base').attr('href', baseUrl);
   }
 
   function getServerDataScript() {


### PR DESCRIPTION
Tested with the blocks-shopping-example with little modifications.
Added a function ``blocks.middleware(options)`` that will return an array.
By default the array contains the middleware (or to be exact the middlewares  ``tryServePage`` method)
and an ``express.static``-instance set to the ``options.static`` folder (can be disabled via option).
Also the middleware will add a base-tag to the head of a page by default (can also be disabled via an option), so relative urls can be used in e.g. resources.

Feel free to ask questions if you have some or if you don't like something about this solution :smile: . 