### PR TITLE
Now cloning __props__ and changed order in 'with'

### DIFF
--- a/src/query/DomQuery.js
+++ b/src/query/DomQuery.js
@@ -68,7 +68,7 @@ define([
         $parents: context ? models : [],
         $index: this._dataIndex || null,
         $parentContext: context || null,
-        __props__: context && context.__props__
+        __props__: blocks.clone(context && context.__props__)
       };
       newContext.$context = newContext;
       this._context = newContext;

--- a/src/query/queries.js
+++ b/src/query/queries.js
@@ -220,10 +220,11 @@ define([
         if (this._renderMode != VirtualElement.RenderMode.None) {
           var renderEndTag = this.renderEndTag;
 
+          domQuery.pushContext(value);
+
           if (name) {
             domQuery.addProperty(name, value);
           }
-          domQuery.pushContext(value);
 
           this.renderEndTag = function () {
             domQuery.popContext();


### PR DESCRIPTION
Cloning the __props__ property of contexts to prevent it from being
overwritten e.g. with new Views and changed the order of execution in the
'with'-data-querie to first push the context and then modify it.

This solves the problem that e.g. the ``view``-data-query overrides the ``$view``-property of all views (including none views like the application context).
[Here an example visualising the problem](https://jsfiddle.net/19r7Lsbf/)

I have tested it and thought about if it could have negative side effects.
I didn't found anything.

Closes #129.