### PR TITLE
Fixed issues with the sort-extender described in #132.

### DIFF
--- a/src/query/DomQuery.js
+++ b/src/query/DomQuery.js
@@ -266,6 +266,7 @@ define([
             elementData.observables[observable.__id__ + method.query] = observable;
             observable._elements.push({
               elementId: elementData.id,
+              element: elementData.dom || elementData.virtual._el,
               cache: [method],
               context: context
             });

--- a/src/query/ExtenderHelper.js
+++ b/src/query/ExtenderHelper.js
@@ -130,7 +130,15 @@ define([
         } else if (operation.type == 'sort') {
           if (blocks.isString(operation.sort)) {
             collection = blocks.clone(collection).sort(function (valueA, valueB) {
-              return valueA[operation.sort] - valueB[operation.sort];
+              valueA = blocks.unwrap(valueA[operation.sort]);
+              valueB = blocks.unwrap(valueB[operation.sort]);
+              if (valueA > valueB) {
+                return 1;
+              }
+              if (valueA < valueB) {
+                return -1;
+              }
+              return 0;
             });
           } else if (blocks.isFunction(operation.sort)) {
             collection = blocks.clone(collection).sort(operation.sort.bind(observable.__context__));
@@ -204,11 +212,13 @@ define([
             break;
           case EXISTS:
             newConnections[index] = viewIndex;
+            if (view.__value__.indexOf(collection[index]) != index) {
+              view.move(view.__value__.indexOf(collection[index]), index);
+            }
             viewIndex++;
             break;
         }
       });
-
       view._connections = newConnections;
       view.update = update;
       view.update();

--- a/src/query/ExtenderHelper.js
+++ b/src/query/ExtenderHelper.js
@@ -133,7 +133,7 @@ define([
               return valueA[operation.sort] - valueB[operation.sort];
             });
           } else if (blocks.isFunction(operation.sort)) {
-            collection = blocks.clone(collection).sort(operation.sort);
+            collection = blocks.clone(collection).sort(operation.sort.bind(observable.__context__));
           } else {
             collection = blocks.clone(collection).sort();
           }


### PR DESCRIPTION
Fixed the issues descriped in #132 and added ``observable._elements[].element`` in ``DomQuery.subscribeObservables()`` as some methods (e.g. ``blocks.observable([]).move()`` rely on it.