### PR TITLE
Fixed bug in observable._expressionKeys.

### DIFF
--- a/src/query/Expression.js
+++ b/src/query/Expression.js
@@ -180,8 +180,8 @@ define([
           };
 
           blocks.each(observables, function (observable) {
-            if (!observable._expressionKeys[elementData.id]) {
-              observable._expressionKeys[elementData.id] = true;
+            if (!observable._expressionKeys[elementData.id + (attributeName ||'expression') +'[' + expression + ']']) {
+              observable._expressionKeys[elementData.id + (attributeName ||'expression') +'[' + expression + ']'] = true;
               observable._expressions.push(expressionObj);
             }
 


### PR DESCRIPTION
Now observables with more then one expression on the same element (e.g. multiple attributes) will update all expression and not only the ont that got parsed first.
Fixes #138.