### PR TITLE
Fix #93

### DIFF
--- a/lib/blocks/core.js
+++ b/lib/blocks/core.js
@@ -44,6 +44,7 @@
    * Copies properties from all provided objects into the first object parameter
    *
    * @memberof blocks
+   * @param {boolean} [deepCopy] - If true, the merge becomes recursive (aka. deep copy)
    * @param {Object} obj
    * @param {...Object} objects
    * @returns {Object}
@@ -555,6 +556,10 @@
       var type = blocks.type(value);
       var clone;
       var key;
+
+      if (blocks.isFunction(value.clone)) {
+        return value.clone(deepClone);
+      }
 
       if (type == 'array') {
         return value.slice(0);

--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -134,7 +134,7 @@ define([
         this._super([_this, prototype, dataItem, collection]);
       };
 
-      prototype = prototype || {};
+      prototype = blocks.clone(prototype, true) || {};
       prototype.options = prototype.options || {};
 
       return blocks.inherit(Model, ExtendedModel, prototype);
@@ -475,6 +475,10 @@ define([
       this.View.Defaults = blocks.observable({
         options: { }
       }).extend();
+    },
+    // Application is a singleton. So return a reference instead of a clone.
+    clone: function () {
+      return this;
     }
   };
 });

--- a/src/mvc/View.js
+++ b/src/mvc/View.js
@@ -224,6 +224,10 @@ define([
 
     _error: function () {
       this.loading(false);
+    },
+    // View is a singleton so return a reference
+    clone: function () {
+      return this;
     }
   };
 


### PR DESCRIPTION
Updated jscore dependency.
Implmented ``App#clone`` and ``View#clone`` to return a reference as they are singletons.
Modified ``Model#clone`` to clone all ``prototype``s (the argument in the constructor) values instead of only properties.
Now cloning the ``protoype`` and ``dataItem`` argument in the Model constructor to fix problems with cloned nested models sharing observables.

Closes #93.