### PR TITLE
Better support for module loaders & libaries in serverside rendering.

### DIFF
--- a/lib/blocks/core.js
+++ b/lib/blocks/core.js
@@ -9,14 +9,29 @@
  * Date: @DATE
  */
 (function(global, factory) {
-  if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(global, true);
+  var blocks;
+  // handle jsblocks serverside rendering overrides
+  if (global.__mock__ && global._blocks) {
+    blocks = global._blocks;
   } else {
-    factory(global);
+    blocks = factory(global);
   }
 
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = blocks;
+  } else {
+    global.blocks = blocks;
+  }
+
+  if (typeof define === 'function' && define.amd) {
+    define('blocks', [], function () {
+      return blocks;
+    });
+  }
+
+
   // Pass this if window is not defined yet
-}(typeof window !== 'undefined' ? window : this, function(global, noGlobal) {
+}(typeof window !== 'undefined' ? window : this, function(global) {
   var toString = Object.prototype.toString;
   var slice = Array.prototype.slice;
   var hasOwn = Object.prototype.hasOwnProperty;
@@ -1080,16 +1095,6 @@
 
     return blocks;
   };
-
-  if (typeof define === 'function' && define.amd) {
-    define('blocks', [], function () {
-      return blocks;
-    });
-  }
-
-  if (noGlobal !== true) {
-    global.blocks = blocks;
-  }
 
   return blocks;
 

--- a/src/node/BrowserEnv.js
+++ b/src/node/BrowserEnv.js
@@ -1,6 +1,7 @@
 define([
-  './createBrowserEnvObject'
-], function (createBrowserEnvObject) {
+  './createBrowserEnvObject',
+  '../core'
+], function (createBrowserEnvObject, blocks) {
   var url = require('url');
 
   function BrowserEnv() {
@@ -69,6 +70,7 @@ define([
     _initialize: function () {
       var env = this._env;
       var document = env.document;
+      env.window._blocks = blocks;
 
       document.getElementById = function (id) {
         return (document.__elementsById__ || {})[id] || null;

--- a/src/node/executePageScripts.js
+++ b/src/node/executePageScripts.js
@@ -1,16 +1,17 @@
 define([
-  '../core'
-], function (blocks) {
-  var vm = require('vm');
-  var fs = require('fs');
+  '../core',
+  '../query/ElementsData'
+], function (blocks, ElementsData) {
+ // var vm = require('vm');
 
   function executePageScripts(env, scripts, callback) {
-    var code = '';
+    var code = 'with(window) {';
 
     blocks.each(scripts, function (script) {
       code += script.code + ';';
     });
 
+    code += '}';
     executeCode(env, code, callback);
   }
 

--- a/src/node/findPageScripts.js
+++ b/src/node/findPageScripts.js
@@ -1,8 +1,9 @@
 define([
   '../core',
-  './parseToVirtual'
-], function (blocks, parseToVirtual) {
+  '../query/VirtualElement'
+], function (blocks, VirtualElement) {
   var path = require('path');
+  var fs = require('fs');
 
   function findPageScripts(virtual, static, callback) {
     var scripts = [];
@@ -28,9 +29,7 @@ define([
         src = child.attr('src');
         if (src && !child.attr('data-client-only')) {
           src = path.join(args.static, src);
-          if (blocks.contains(src, 'blocks') && blocks.endsWith(src, '.js')) {
-            src = 'node_modules/blocks/blocks.js';
-          }
+
           scripts.push({
             type: 'external',
             url: src,


### PR DESCRIPTION
Let me first explain the problem:
I need to work with a  jsblocks project that uses [webpack](https://github.com/webpack/webpack) for bundling so all js is in one file. 
Webpack defines itself on the ``window`` object as a global, I added a ``with(window){}`` to the new Function call. I also added ``_blocks`` to the window object that contains the node-blocks instance and will be returned by the change in the jscore libary.

Feel free to ask questions if you have some.




Summary: 
Updated jscore to PR astoilkov/jscore#4.
Some external libaries (including module loaders and some code optimiziers (e.g. uglify)) rely on 'window' beeing the super-global, added 'with' statement in serverside rendering to satisfy that need.
Added property 'window._blocks' to serverside rendering context for the jscore define change.
Moved some 'require'-calls to the right files.