### PR TITLE
Fixed / Implemented debug messages for "normal" methods.

### DIFF
--- a/lib/blocks/core.js
+++ b/lib/blocks/core.js
@@ -520,7 +520,7 @@
      * If the value could not be parsed to a number it is not converted
      *
      * @memberof blocks
-     * @param {[type]} value - The value to be converted to the specified unit
+     * @param {String|Number} value - The value to be converted to the specified unit
      * @param {String} [unit='px'] - Optionally provide a unit to convert to.
      * Default value is 'px'
      *

--- a/lib/blocks/core.js
+++ b/lib/blocks/core.js
@@ -440,11 +440,15 @@
      * Unwraps a jQuery instance and returns the first element
      *
      * @param {*} element - If jQuery element is specified it will be unwraped
+     * @param {Function} [callback] - Callback the element will be passed to.
+     * @param {*} [thisArg] - The context the callback will be executed with
      * @returns {*} - The unwraped value
      *
      * @example {javascript}
      * var articles = $('.article');
-     * blocks.$unwrap()
+     * blocks.$unwrap(articles, function (article) {
+     *   console.log(artice.textContent);
+     * });
      */
     $unwrap: function(element, callback, thisArg) {
       callback = parseCallback(callback, thisArg);
@@ -682,7 +686,7 @@
      * Determines if the specified value is an object
      *
      * @memberof blocks
-     * @param {[type]} obj - The value to check for if it is an object
+     * @param {*} obj - The value to check for if it is an object
      * @returns {boolean} - Returns whether the value is an object
      */
     isObject: function(obj) {

--- a/lib/blocks/core.js
+++ b/lib/blocks/core.js
@@ -1062,13 +1062,11 @@
     return callback;
   }
 
-  (function () {
-    // @debug-code
-  })();
 
-  (function () {
-    // @source-code
-  })();
+  // @debug-code
+
+  // @source-code
+
 
   /* @if DEBUG */
   (function() {

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -390,7 +390,7 @@ function checkArgsTypes(method, args) {
   var params = method.params;
   var maxOptionals = params.length - (params.length - getOptionalParamsCount(method.params));
   var paramIndex = 0;
-  var passDetailValues = blocks.queries[method.name].passDetailValues;
+  var passDetailValues = blocks.queries[method.name] && blocks.queries[method.name].passDetailValues;
   var currentErrors;
   var param;
   var value;

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -2,7 +2,7 @@
 var customTypes = {};
 
 blocks.debug = {
-  enabled: true,
+  enabled: false,
 
   enable: function () {
     blocks.debug.enabled = true;
@@ -390,7 +390,7 @@ function checkArgsTypes(method, args) {
   var params = method.params;
   var maxOptionals = params.length - (params.length - getOptionalParamsCount(method.params));
   var paramIndex = 0;
-  var passDetailValues = blocks.queries[method.name] && blocks.queries[method.name].passDetailValues;
+  var passDetailValues = blocks.queries && blocks.queries[method.name] && blocks.queries[method.name].passDetailValues;
   var currentErrors;
   var param;
   var value;
@@ -467,7 +467,7 @@ function checkType(param, value) {
         continue;
       }
     } else if (blocks.isObservable(value)) {
-      valueType = 'blocks.observable()';
+      valueType = 'blocks.observable';
     } else {
       valueType = blocks.type(value).toLowerCase();
     }
@@ -475,7 +475,7 @@ function checkType(param, value) {
     if (type === valueType) {
       satisfied = true;
       break;
-    } else if (valueType == 'blocks.observable()') {
+    } else if (valueType == 'blocks.observable') {
       valueType = blocks.type(blocks.unwrapObservable(value));
       if (type === valueType) {
         satisfied = true;

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -1,4 +1,4 @@
-
+/* globals blocks */
 var customTypes = {};
 
 blocks.debug = {
@@ -213,7 +213,7 @@ function addMethodReference(message, method, examplesExpanded) {
 
 function addCodeTree(message, codeTree) {
   var children = codeTree.children;
-  var lines;
+  //var lines;
   var child;
 
   message.beginSpan(highlightjs[codeTree.name]);
@@ -653,25 +653,6 @@ ConsoleMessage.prototype = {
     return this;
   },
 
-  addImage: function () {
-    (function () {
-      var faviconUrl = "http://d2c87l0yth4zbw.cloudfront.net/i/_global/favicon.png",
-        css = "background-image: url('" + faviconUrl + "');" +
-          "background-repeat: no-repeat;" +
-          "display: block;" +
-          "background-size: 13px 13px;" +
-          "padding-left: 13px;" +
-          "margin-left: 5px;",
-        text = "Do you like coding? Visit www.spotify.com/jobs";
-      if (navigator.userAgent.match(/chrome/i)) {
-        console.log(text + '%c', css);
-      } else {
-        console.log('%c   ' + text, css);
-      }
-    })();
-    return this;
-  },
-
   addElement: function (element) {
     this._currentSpan.children.push({
       type: 'element',
@@ -726,7 +707,7 @@ ConsoleMessage.prototype = {
         message = this._newMessage('groupEnd');
         message.text = ' ';
         messages.push(message);
-        messages.push(this._newMessage())
+        messages.push(this._newMessage());
         break;
       case 'span':
         this._printSpan(child, messages);

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -391,13 +391,17 @@ function checkArgsTypes(method, args) {
   var maxOptionals = params.length - (params.length - getOptionalParamsCount(method.params));
   var paramIndex = 0;
   var passDetailValues = blocks.queries && blocks.queries[method.name] && blocks.queries[method.name].passDetailValues;
+  var mustSkipOptionals = args.length < params.length;
   var currentErrors;
   var param;
+  var nextParam;
+  var hasArguments = hasArgumentsParam(method);
   var value;
 
   for (var i = 0; i < args.length; i++) {
     param = params[paramIndex];
     value = args[i];
+    nextParam = params[paramIndex + 1];
 
     if (!param) {
       break;
@@ -409,20 +413,29 @@ function checkArgsTypes(method, args) {
 
     if (param.optional) {
       if (maxOptionals > 0) {
+        // Skips optional parameters, if it has the same type as the following parameter, not enough parameters are specified and the next param is not optional.
+        // One exmple function is Application.View([string], string, object)
+        if (mustSkipOptionals && nextParam && !nextParam.optional && blocks.equals(param.types, nextParam.types, true)) {
+          paramIndex++;
+          param = nextParam;
+        }
         currentErrors = checkType(param, value);
         if (currentErrors.length === 0) {
           maxOptionals -= 1;
           if (!param.isArguments) {
             paramIndex += 1;
           }
+        } else if (mustSkipOptionals || hasArguments) {
+          currentErrors = [];
         }
       }
     } else {
-      errors = errors.concat(checkType(param, value));
+      currentErrors = checkType(param, value);
       if (!param.isArguments) {
         paramIndex += 1;
       }
     }
+    errors = errors.concat(currentErrors);
   }
 
   return errors;
@@ -454,6 +467,15 @@ function checkType(param, value) {
       }
     } else if (type == 'truthy') {
       if (unwrapedValue) {
+        satisfied = true;
+        break;
+      } else {
+        continue;
+      }
+      // htmlelement type used in "blocks.query"
+    } else if (type == 'htmlelement') {
+      var element = blocks.$unwrap(unwrapedValue);
+      if (blocks.isElement(element)) {
         satisfied = true;
         break;
       } else {
@@ -550,6 +572,16 @@ function params(method) {
   for (var i = 0; i < params.length; i++) {
     console.log('    ' + method.params[i].name + ': ' + method.params[i].description);
   }
+}
+
+function hasArgumentsParam(method) {
+  var params = method.params;
+  for (var i = 0; i < params.length; i++) {
+    if (params[i].isArguments) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function ConsoleMessage() {

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -200,12 +200,14 @@ function addMethodReference(message, method, examplesExpanded) {
     message.beginCollapsedGroup();
   }
 
-  message
-    .addSpan('Usage example' + (examples.length > 1 ? 's' : ''), { color: 'blue' })
-    .newLine();
+  if (examples.length > 0) {
+    message
+      .addSpan('Usage example' + (examples.length > 1 ? 's' : ''), { color: 'blue' })
+      .newLine();
 
-  for (var i = 0; i < method.examples.length;i++) {
-    addCodeTree(message, method.examples[i].code);
+    for (var i = 0; i < examples.length;i++) {
+      addCodeTree(message, examples[i].code);
+    }
   }
 
   message.endGroup();

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -11,11 +11,16 @@ blocks.debug = {
   disable: function () {
     blocks.debug.enabled = false;
   },
-
+  pause: function () {
+    blocks.debug.paused++;
+  },
+  resume: function () {
+    blocks.debug.paused--;
+  },
   addType: function (name, checkCallback) {
     customTypes[name.toLowerCase()] = checkCallback;
   },
-
+  paused: 0,
   checkArgs: debugFunc(function (method, args, options) {
     if (!blocks.debug.enabled) {
       return;
@@ -74,8 +79,8 @@ blocks.debug = {
     message.print();
   },
 
-  checkQuery: function (name, args, query, element) {
-    if (!blocks.debug.enabled || name == 'if' || name == 'ifnot') {
+  checkQuery: debugFunc(function (name, args, query, element) {
+    if (name == 'if' || name == 'ifnot') {
       return;
     }
     var method = blocks.debug.queries[name];
@@ -85,12 +90,9 @@ blocks.debug = {
         element: element
       });
     }
-  },
+  }),
 
-  queryNotExists: function (query, element) {
-    if (!blocks.debug.enabled) {
-      return;
-    }
+  queryNotExists: debugFunc(function (query, element) {
     var message = blocks.debug.Message();
     message.beginSpan({ 'font-weight': 'bold' });
     message.addSpan('Warning:', { background: 'orange', padding: '0 3px' });
@@ -106,12 +108,9 @@ blocks.debug = {
     message.endSpan();
 
     message.print();
-  },
+  }),
 
-  queryParameterFail: function (query, failedParameter, element) {
-    if (!blocks.debug.enabled) {
-      return;
-    }
+  queryParameterFail: debugFunc(function (query, failedParameter, element) {
     var method = blocks.debug.queries[query.name];
     var message = blocks.debug.Message();
     var params = query.params;
@@ -146,9 +145,9 @@ blocks.debug = {
     message.endGroup();
 
     message.print();
-  },
+  }),
 
-  expressionFail: function (expressionText, element) {
+  expressionFail: debugFunc(function (expressionText, element) {
     if (!blocks.debug.enabled) {
       return;
     }
@@ -164,7 +163,7 @@ blocks.debug = {
     tryInsertElement(message, element);
 
     message.print();
-  },
+  }),
 
   Message: ConsoleMessage
 };
@@ -320,7 +319,7 @@ function addError(message, error, method, paramNames) {
 
 function debugFunc(callback) {
   return function () {
-    if (blocks.debug.executing||!blocks.debug.enabled) {
+    if (blocks.debug.executing || !blocks.debug.enabled || blocks.debug.paused > 0) {
       return;
     }
     blocks.debug.executing = true;

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -257,14 +257,14 @@ function addError(message, error, method, paramNames) {
         if (error.actual > 0) {
           message.addText(', ');
         }
-        for (index = 0; index < error.expected; index++) {
+        for (index = error.actual; index < error.expected; index++) {
           message
             .beginSpan({
               'background-color': 'red',
               padding: '0 5px',
               color: 'white'
             })
-            .addText('?')
+            .addText(paramNames[index] || '?')
             .endSpan();
           if (index != error.expected - 1) {
             message.addText(', ');
@@ -320,7 +320,7 @@ function addError(message, error, method, paramNames) {
 
 function debugFunc(callback) {
   return function () {
-    if (blocks.debug.executing) {
+    if (blocks.debug.executing||!blocks.debug.enabled) {
       return;
     }
     blocks.debug.executing = true;

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -454,6 +454,11 @@ function checkType(param, value) {
     type = types[i].toLowerCase();
     type = type.replace('...', '');
 
+    if (param.optional && blocks.isUndefined(unwrapedValue)) {
+      satisfied = true;
+      break;
+    }
+
     if (type == '*') {
       satisfied = true;
       break;

--- a/src/modules/Router.js
+++ b/src/modules/Router.js
@@ -347,7 +347,7 @@
       var optionalParameters = [];
 
       blocks.each(routeData, function (split) {
-        if (blocks.has(route._optional, split.param)) {
+        if (route._optional && split.param && blocks.has(route._optional, split.param)) {
           optionalParameters.push(split.param);
         }
       });

--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -51,7 +51,7 @@ define([
      * Creates an application property for a Model
      *
      * @memberof Application
-     * @param {Object)} property - An object describing the options for the current property
+     * @param {Object} [property] - An object describing the options for the current property
      *
      * @example {javascript}
      *
@@ -144,6 +144,7 @@ define([
     * Creates a new Collection
     *
     * @memberof Application
+    * @param {Object} [ModelType] - The model type the collection will be created for.
     * @param {Object} prototype - The Collection object properties that will be created.
     * @returns {Collection} - The Collection type with the specified properties
     * @example {javascript}
@@ -219,10 +220,10 @@ define([
       };
 
       if (!ModelType) {
-        ModelType = this.Model();
+        ModelType = this.Model({});
       } else if (!Model.prototype.isPrototypeOf(ModelType.prototype)) {
         prototype = ModelType;
-        ModelType = this.Model();
+        ModelType = this.Model({});
       }
       prototype = prototype || {};
       prototype.options = prototype.options || {};
@@ -286,11 +287,11 @@ define([
       if (!this._started) {
         this._started = true;
         this._serverData = window.__blocksServerData__;
-        
+
         if (this._serverData && this._serverData.baseUrl) {
           this._router._setBaseUrl(this._serverData.baseUrl);
         }
-        
+
         this._createViews();
         blocks.domReady(blocks.bind(this._ready, this, element));
       }
@@ -347,7 +348,7 @@ define([
     _urlChange: function (data) {
       var _this = this;
       var currentView = this._currentView;
-      var routes = this._router.routeFrom(data.url);
+      var routes = this._router.routeFrom(data.url) || [];
       var found = false;
 
       blocks.each(routes, function (route) {

--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -144,7 +144,7 @@ define([
     * Creates a new Collection
     *
     * @memberof Application
-    * @param {Object} [ModelType] - The model type the collection will be created for.
+    * @param {Object|blocks.Application.Model} [ModelType] - The model type the collection will be created for.
     * @param {Object} prototype - The Collection object properties that will be created.
     * @returns {Collection} - The Collection type with the specified properties
     * @example {javascript}
@@ -474,7 +474,7 @@ define([
       }).extend();
 
       this.View.Defaults = blocks.observable({
-        options: { }
+        options: {}
       }).extend();
     },
     // Application is a singleton. So return a reference instead of a clone.

--- a/src/mvc/Collection.js
+++ b/src/mvc/Collection.js
@@ -29,7 +29,7 @@ define([
 
     observable._baseUpdate = observable.update;
     blocks.each(blocks.observable.fn.collection, function (value, key) {
-      if (blocks.isFunction(value) && key.indexOf('_') !== 0) {
+      if (blocks.isFunction(value) && key.indexOf('_') !== 0 && blocks.isFunction(observable[key])) {
         observable[key] = blocks.bind(observable[key], observable);
       }
     });
@@ -177,12 +177,13 @@ define([
       return this;
     },
 
+    //@todo docs -> What does it do with args ?
     /**
-     *
+     * Performs updates on elements, expressions, etc. like obervable.update() when called without arguments.
      *
      * @memberof Collection
-     * @param {number} id -
-     * @param {Object} newValues -
+     * @param {number} [id] - The id of the element to trigger the update for
+     * @param {Object} [newValues] - The new values to apply
      * @returns {Collection} - Chainable. Returns the Collection itself - return this;
      */
     update: function (id, newValues) {

--- a/src/mvc/Collection.js
+++ b/src/mvc/Collection.js
@@ -73,6 +73,7 @@ define([
      * @memberof Collection
      * @param {Object} [params] - The parameters Object that will be used to populate the
      * Collection from the specified options.read URL. If the URL does not contain parameters
+     * @param {Function} [callback] - A callback function that will be called when the data is available.
      * @returns {Collection} - Chainable. Returns the Collection itself - return this;
      *
      * @example {javascript}

--- a/src/mvc/Model.js
+++ b/src/mvc/Model.js
@@ -197,10 +197,12 @@ define([
     },
 
     /**
-     * Applies new properties to the Model by providing an Object
+     * Applies new properties to the Model by providing an Object.
+     * If no object is provided all App.Properties will be set to their "defaulValue" or undefined.
+     * All observables will be set to undefined.
      *
      * @memberof Model
-     * @param {Object} dataItem - The object from which the new values will be applied
+     * @param {Object} [dataItem] - The object from which the new values will be applied
      * @returns {Model} - Chainable. Returns itself
      */
     reset: function (dataItem) {

--- a/src/mvc/Model.js
+++ b/src/mvc/Model.js
@@ -380,8 +380,16 @@ define([
       this.validationErrors.reset(result);
     }
   };
-
   if (blocks.core.expressionsCreated) {
     blocks.core.applyExpressions('object', Model.prototype);
   }
+  // @if DEBUG
+  blocks.debug.addType('blocks.Application.ModelInstance', function (value) {
+    return value && value instanceof Model;
+  });
+
+  blocks.debug.addType('blocks.Application.Model', function (value) {
+    return value && value.prototype && value.prototype.__Class__ == Model;
+  });
+  // @endif
 });

--- a/src/mvc/Property.js
+++ b/src/mvc/Property.js
@@ -40,9 +40,11 @@
       .on('changing', options.changing, thisArg)
       .on('change', options.change, thisArg);
 
-    blocks.each(options.extenders, function (extendee) {
-      observable = observable.extend.apply(observable, extendee);
-    });
+    if (options.extenders) {
+      blocks.each(options.extenders, function (extendee) {
+        observable = observable.extend.apply(observable, extendee);
+      });
+    }
 
     return observable;
   };

--- a/src/mvc/bindContext.js
+++ b/src/mvc/bindContext.js
@@ -4,7 +4,7 @@ define([
 	function bindContext (context, object) {
 		var key;
 		var value;
-		
+		/* @if DEBUG */ blocks.debug.pause(); /* @endif */
 		if (!object) {
 			object = context;
 		}
@@ -19,6 +19,7 @@ define([
 			}
 
 		}
+		/* @if DEBUG */ blocks.debug.resume(); /* @endif */
 	}
 	return bindContext;
 });

--- a/src/query/ElementsData.js
+++ b/src/query/ElementsData.js
@@ -6,7 +6,7 @@
   var ElementsData = (function () {
     var data = {};
     var globalId = 1;
-    
+
     function getDataId(element) {
       var result = element ? VirtualElement.Is(element) ? element._state ? element._state.attributes[dataIdAttr] : element._attributes[dataIdAttr] :
         element.nodeType == 1 ? element.getAttribute(dataIdAttr) :
@@ -49,7 +49,7 @@
         var isVirtual = element && element.__identity__ == virtualElementIdentity;
         var currentData;
         var id;
-        
+
         if (isVirtual) {
           currentData = data[element._getAttr(dataIdAttr)];
         } else {
@@ -133,7 +133,7 @@
           });
           data[id] = undefined;
           if (VirtualElement.Is(element)) {
-            element.attr(dataIdAttr, null);
+            element.removeAttr(dataIdAttr);
           } else if (element.nodeType == 1) {
             element.removeAttribute(dataIdAttr);
           }

--- a/src/query/VirtualElement.js
+++ b/src/query/VirtualElement.js
@@ -78,9 +78,9 @@ define([
     /**
      * Gets or sets the inner text of the element.
      *
-     * @param {String} [html] - The new text that will be set. Provide the parameter only if you want to set new text.
-     * @returns {String|VirtualElement} - returns itself if it is used as a setter(no parameters specified)
-     * and returns the inner text of the element if it used as a getter.
+     * @param {String} [text] - The new text that will be set. Provide the parameter only if you want to set new text.
+     * @returns {String|VirtualElement} - returns itself if it is used as a setter
+     * and returns the inner text of the element if it used as a getter (no parameters specified).
      */
     text: function (text) {
       if (arguments.length > 0) {
@@ -113,7 +113,7 @@ define([
      * Gets or sets an attribute value
      *
      * @param {String} attributeName - The attribute name to be set or retrieved.
-     * @param {String} [attributeValue] - The value to be set to the attribute.
+     * @param {String|Number|boolean} [attributeValue] - The value to be set to the attribute.
      * @returns {VirtualElement|String} - Returns the VirtualElement itself if you set an attribute.
      * Returns the attribute name value if only the first parameter is specified.
      */
@@ -206,7 +206,7 @@ define([
      * Gets or sets a CSS property
      *
      * @param {String} name - The CSS property name to be set or retrieved
-     * @param {String} [value] - The value to be set to the CSS property
+     * @param {String|number|boolean} [value] - The value to be set to the CSS property
      * @returns {VirtualElement|String} - Returns the VirtualElement itself if you use the method as a setter.
      * Returns the CSS property value if only the first parameter is specified.
      */
@@ -754,6 +754,9 @@ define([
   function replaceStyleAttribute(match) {
     return '-' + match.toLowerCase();
   }
+  //@if DEBUG
+  blocks.debug.addType('blocks.VirtualElement', VirtualElement.Is);
+  //@endif
 
   return VirtualElement;
 });

--- a/src/query/extenders.js
+++ b/src/query/extenders.js
@@ -57,7 +57,7 @@ define([
    * items are skipped
    *
    * @memberof extenders
-   * @param {(number|blocks.observable)} value - The number of items to be skipped
+   * @param {(number|blocks.observable|Function)} value - The number of items to be skipped
    * @returns {blocks.observable} - Returns a new observable
    * containing a .view property with the manipulated data
    */
@@ -77,7 +77,7 @@ define([
    * always maximum n items
    *
    * @memberof extenders
-   * @param {(number|blocks.observable))} value - The max number of items to be in the collection
+   * @param {(number|blocks.observable|Function)} value - The max number of items to be in the collection
    * @returns {blocks.observable} - Returns a new observable
    * containing a .view property with the manipulated data
    */

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -55,9 +55,9 @@ define([
     };
 
     initialValue = blocks.unwrap(initialValue);
-    /* @if DEBUG */ blocks.debug.executing = true; /* @endif */
+    /* @if DEBUG */ blocks.debug.pause(); /* @endif */
     blocks.extend(observable, blocks.observable.fn.base);
-    /* @if DEBUG */ blocks.debug.executing = false; /* @endif */
+    /* @if DEBUG */ blocks.debug.resume(); /* @endif */
     observable.__id__ = observableId++;
     observable.__value__ = initialValue;
     observable.__context__ = thisArg || blocks.__viewInInitialize__ || observable;
@@ -87,7 +87,9 @@ define([
 
   function updateDependencies(observable) {
     if (observable._dependencyType) {
+      /* @if DEBUG */ blocks.debug.pause(); /* @endif */
       observable._getDependency = blocks.bind(getDependency, observable);
+      /* @if DEBUG */ blocks.debug.resume(); /* @endif */
       observable.on('get', observable._getDependency);
     }
   }

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -568,13 +568,14 @@ define([
          * to be removed by providing a callback
          *
          * @memberof array
-         * @param {Function} [callback] - Optional callback function which filters which items
-         * to be removed. Returning a truthy value will remove the item and vice versa
+         * @param {Function|*} [callbackOrValue] - Optional callback function which filters which items
+         * to be removed. Returning a truthy value will remove the item and vice versa.
+         * If the passed value is not a function value matching the passed value will be removed.
          * @param {*} [thisArg] - Optional this context for the callback function
          * @param {boolean} [removeOne] - If set only the first entry will be removed. Mostly used in internal functions.
          * @returns {blocks.observable} - Returns the observable itself - return this;
          */
-        removeAll: function (callback, thisArg, removeOne) {
+        removeAll: function (callbackOrValue, thisArg, removeOne) {
           var array = this.__value__;
           var chunkManager = this._chunkManager;
           var items;
@@ -601,12 +602,12 @@ define([
               index: 0
             });
           } else {
-            var isCallbackAFunction = blocks.isFunction(callback);
+            var isCallbackAFunction = blocks.isFunction(callbackOrValue);
             var value;
 
             for (i = 0; i < array.length; i++) {
               value = array[i];
-              if (value === callback || (isCallbackAFunction && callback.call(thisArg, value, i, array))) {
+              if (value === callbackOrValue || (isCallbackAFunction && callbackOrValue.call(thisArg, value, i, array))) {
                 this.splice(i, 1);
                 i -= 1;
                 if (removeOne) {
@@ -714,7 +715,7 @@ define([
          * @returns {number} The new length of the observable array
          */
         push: function () {
-          this.addMany(arguments);
+          this.addMany(blocks.toArray(arguments));
           return this.__value__.length;
         },
 
@@ -898,7 +899,7 @@ define([
          * @returns {number} The new length of the observable array.
          */
         unshift: function () {
-          this.addMany(arguments, 0);
+          this.addMany(blocks.toArray(arguments), 0);
           return this.__value__.length;
         }
       }

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -55,8 +55,9 @@ define([
     };
 
     initialValue = blocks.unwrap(initialValue);
-
+    /* @if DEBUG */ blocks.debug.executing = true; /* @endif */
     blocks.extend(observable, blocks.observable.fn.base);
+    /* @if DEBUG */ blocks.debug.executing = false; /* @endif */
     observable.__id__ = observableId++;
     observable.__value__ = initialValue;
     observable.__context__ = thisArg || blocks.__viewInInitialize__ || observable;

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -18,8 +18,8 @@ define([
 
   /**
   * @namespace blocks.observable
-  * @param {*} initialValue -
-  * @param {*} [context] -
+  * @param {*} initialValue - The inital value of the observable. This value will also specify the functions the observable inherits (e.g. array specific functions). Do not change types of observables later.
+  * @param {*} [context] - The context the observable will be bound to.
   * @returns {blocks.observable}
   */
   blocks.observable = function (initialValue, thisArg) {
@@ -246,14 +246,18 @@ define([
             }
           }
 
-          blocks.each(this._dependencies, function updateDependency(dependency) {
-            updateDependencies(dependency);
-            dependency.update();
-          });
+          if (this._dependencies) {
+            blocks.each(this._dependencies, function updateDependency(dependency) {
+              updateDependencies(dependency);
+              dependency.update();
+            });
+          }
 
-          blocks.each(this._indexes, function updateIndex(observable, index) {
-            observable(index);
-          });
+          if (this._indexes) {
+            blocks.each(this._indexes, function updateIndex(observable, index) {
+              observable(index);
+            });
+          }
 
           Observer.stopObserving();
 
@@ -344,7 +348,7 @@ define([
          * The value could be Array, observable array or jsvalue.Array
          *
          * @memberof array
-         * @param {Array} value - The new value that will be populated
+         * @param {Array|Null|Undefined} [value] - The new value that will be populated
          * @returns {blocks.observable} - Returns the observable itself - return this;
          *
          * @example {javascript}
@@ -567,6 +571,7 @@ define([
          * @param {Function} [callback] - Optional callback function which filters which items
          * to be removed. Returning a truthy value will remove the item and vice versa
          * @param {*} [thisArg] - Optional this context for the callback function
+         * @param {boolean} [removeOne] - If set only the first entry will be removed. Mostly used in internal functions.
          * @returns {blocks.observable} - Returns the observable itself - return this;
          */
         removeAll: function (callback, thisArg, removeOne) {
@@ -827,10 +832,10 @@ define([
          * Adds and/or removes elements from the observable array
          *
          * @memberof array
-         * @param {number} index An integer that specifies at what position to add/remove items.
+         * @param {number} index - An integer that specifies at what position to add/remove items.
          * Use negative values to specify the position from the end of the array.
-         * @param {number} howMany The number of items to be removed. If set to 0, no items will be removed.
-         * @param {...*} The new item(s) to be added to the array.
+         * @param {number} howMany - The number of items to be removed. If set to 0, no items will be removed.
+         * @param {...*} [items] - The new item(s) to be added to the array.
          * @returns {Array} A new array containing the removed items, if any.
          */
         splice: function (index, howMany) {


### PR DESCRIPTION
This is a huge PR because I had to fix some jsdoc and internal usage of functions, so that they don't throw errors.

Please take a look at the messages and diffs of the commits and not the whole diff.
The (imho) interesting commits are: 
https://github.com/astoilkov/jsblocks/commit/7f337f7eedd48fd4c1e7b28aa3abd87bd1e878b7
https://github.com/astoilkov/jsblocks/commit/fbb8831753d3bbddb2fed5978714833161c0d1ab
https://github.com/astoilkov/jsblocks/commit/666724987005175d9b39252987e22707010ad8d5

The other commits are mostly fixes of jsdoc params and internal usage of the methods that differ from the docs.  

This enables debug messages for normal methods (on param misuse, I'll implement custom errors from methods after this is merged).
I've tested it against the tests (only tests that misuse the API are throwing messages) and the shopping-example. In the shopping example only one observable that is initialized without a parameter throws a message (is this a bug in the shopping-example or should all params of the obervable be optional ?).

I also updated jscore to astoilkov/jscore#5.

Btw. I should have time to work a bit on js(blocks|core|value) in the next few weeks :smile: so expect so more PRs.

Edit: If there is a repository for jsdebug (because it looks kinda "built") please point me to it and I'll backport the changes.