### PR TITLE
Debugging enhancments (custom Messages and more )

### DIFF
--- a/build/tasks/debug.js
+++ b/build/tasks/debug.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
         if (func) {
           // FunctionExpression.BlockStatement.body(Array)
           var funcBody = func.body.body;
-          esprima.parse('blocks.debug && blocks.debug.checkArgs(' + toValueString(data) + ', Array.prototype.slice.call(arguments), {})').body.forEach(function (chunk) {
+          esprima.parse('blocks.debug && blocks.debug.checkArgs(__DEBUG_METHOD, Array.prototype.slice.call(arguments), {}); var __DEBUG_METHOD = ' + toValueString(data) + ';').body.forEach(function (chunk) {
             funcBody.unshift(chunk);
           });
         }

--- a/build/tasks/debug.js
+++ b/build/tasks/debug.js
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
           // FunctionExpression.BlockStatement.body(Array)
           var funcBody = func.body.body;
           methods[++methodId] = data;
-          funcBody.unshift.apply(funcBody, esprima.parse('var __METHOD_ID = ' + methodId + '; blocks.debug && blocks.debug.checkArgs(blocks.debug.methods[__METHOD_ID], Array.prototype.slice.call(arguments), {});').body);
+          funcBody.unshift.apply(funcBody, esprima.parse('var __METHOD_ID = ' + methodId + '; if (blocks.debug && blocks.debug.available()) { blocks.debug.checkArgs(blocks.debug.methods[__METHOD_ID], Array.prototype.slice.call(arguments), {});}').body);
         }
       }
     });

--- a/build/tasks/debug.js
+++ b/build/tasks/debug.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
         if (func) {
           // FunctionExpression.BlockStatement.body(Array)
           var funcBody = func.body.body;
-          esprima.parse('blocks.debug && blocks.debug.checkArgs(__DEBUG_METHOD, Array.prototype.slice.call(arguments), {}); var __DEBUG_METHOD = ' + toValueString(data) + ';').body.forEach(function (chunk) {
+          esprima.parse('var __DEBUG_METHOD = ' + toValueString(data) + '; blocks.debug && blocks.debug.checkArgs(__DEBUG_METHOD, Array.prototype.slice.call(arguments), {});').body.reverse().forEach(function (chunk) {
             funcBody.unshift(chunk);
           });
         }

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -37,6 +37,44 @@ blocks.debug = {
     blocks.debug.printErrors(method, args, options, errors);
   }),
 
+  throwMessage: debugFunc(function(errorMessage, method, style) {
+    if (!errorMessage) return;
+
+    var type = typeof style == 'string' ? style : 'Info';
+
+    if (!style || typeof style != 'object') {
+        style = defaultStyles[type.toLowerCase()];
+    }
+
+    var message = blocks.debug.Message();
+
+    message.addSpan(type, style).addText(' in ');
+
+    // No method => No name and no usage, so we at least print a stack trace
+    if (!method) {
+      message.addText('unspecified method - ')
+        .addText(errorMessage);
+
+      message.beginCollapsedGroup();
+
+      message.addText('Stack trace:')
+        .newLine()
+        .addText(new Error().stack);
+
+      message.endGroup();
+    }
+
+    // Print method name, error message and add usage
+    if (method) {
+      message.addSpan(method.name + '()', {background: '#EEE'})
+        .addText(' - ')
+        .addText(errorMessage);
+      addMethodReference(message, method, true);
+    }
+
+    message.print();
+  }),
+
   printErrors: function (method, args, options, errors) {
     if (!blocks.debug.enabled) {
       return;
@@ -275,7 +313,7 @@ function addError(message, error, method, paramNames) {
           message.addText(', ');
         }
         for (index = error.expected; index < error.actual; index++) {
-          message.addSpan(paramNames[index], blocks.extend({}, defaultStyles.error,{'text-decoration': 'line-through'}));
+          message.addSpan(paramNames[index], blocks.extend({}, defaultStyles.error, {'text-decoration': 'line-through'}));
           if (index != error.actual - 1) {
             message.addText(', ');
           }

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -52,7 +52,7 @@ blocks.debug = {
     }
 
     message
-      .addSpan('Arguments mismatch:', { background: 'yellow'})
+      .addSpan('Arguments mismatch:', defaultStyles.info)
       .addText(' ');
 
     if (one) {
@@ -95,10 +95,10 @@ blocks.debug = {
   queryNotExists: debugFunc(function (query, element) {
     var message = blocks.debug.Message();
     message.beginSpan({ 'font-weight': 'bold' });
-    message.addSpan('Warning:', { background: 'orange', padding: '0 3px' });
+    message.addSpan('Warning:', blocks.extend({}, defaultStyles.warning, {padding: '0 3px' }));
 
     message.addText(' ');
-    message.addSpan(query.name, { background: 'red', color: 'white' });
+    message.addSpan(query.name, defaultStyles.error);
     message.addSpan('(' + query.params.join(', ') + ')', { background: '#EEE' });
 
     message.addText(' - data-query ');
@@ -122,14 +122,14 @@ blocks.debug = {
 
     message.beginCollapsedGroup();
     message.beginSpan({ 'font-weight': 'bold' });
-    message.addSpan('Critical:', { background: 'red', color: 'white' });
+    message.addSpan('Critical:', defaultStyles.error);
     message.addText(' ');
     message.beginSpan({ background: '#EEE' });
     message.addText(query.name + '(');
     for (var i = 0; i < params.length; i++) {
       param = params[i];
       if (param == failedParameter) {
-        message.addSpan(param, { background: 'red', color: 'white' });
+        message.addSpan(param, defaultStyles.error);
       } else {
         message.addText(param);
       }
@@ -154,9 +154,9 @@ blocks.debug = {
     var message = new blocks.debug.Message();
 
     message.beginSpan({ 'font-weight': 'bold' });
-    message.addSpan('Critical:', { background: 'red', color: 'white' });
+    message.addSpan('Critical:', defaultStyles.error);
     message.addText(' ');
-    message.addSpan('{{' + expressionText + '}}', { background: 'red', color: 'white' });
+    message.addSpan('{{' + expressionText + '}}', defaultStyles.error);
     message.addText(' - exception thrown while executing expression');
     message.endSpan();
 
@@ -244,7 +244,7 @@ function addError(message, error, method, paramNames) {
   }
 
   message.beginSpan({
-    'background-color': '#EEE'
+    'background': '#EEE'
   });
 
   message.addText(method.name + '(');
@@ -258,11 +258,7 @@ function addError(message, error, method, paramNames) {
         }
         for (index = error.actual; index < error.expected; index++) {
           message
-            .beginSpan({
-              'background-color': 'red',
-              padding: '0 5px',
-              color: 'white'
-            })
+            .beginSpan(blocks.extend({}, defaultStyles.error, {  padding: '0 5px'}))
             .addText(paramNames[index] || '?')
             .endSpan();
           if (index != error.expected - 1) {
@@ -279,11 +275,7 @@ function addError(message, error, method, paramNames) {
           message.addText(', ');
         }
         for (index = error.expected; index < error.actual; index++) {
-          message.addSpan(paramNames[index], {
-            'background-color': 'red',
-            'text-decoration': 'line-through',
-            color: 'white'
-          });
+          message.addSpan(paramNames[index], blocks.extend({}, defaultStyles.error,{'text-decoration': 'line-through'}));
           if (index != error.actual - 1) {
             message.addText(', ');
           }
@@ -295,10 +287,7 @@ function addError(message, error, method, paramNames) {
       case 'param':
         for (index = 0; index < paramNames.length; index++) {
           if (method.params[index] == error.param) {
-            message.addSpan(paramNames[index], {
-              'background-color': 'red',
-              color: 'white'
-            });
+            message.addSpan(paramNames[index], defaultStyles.error);
           } else {
             message.addText(paramNames[index]);
           }
@@ -556,30 +545,6 @@ function addMethodSignature(message, method) {
   message.newLine();
 }
 
-function examples(method) {
-  var examples = method.examples;
-
-  if (examples) {
-    console.groupCollapsed('%cUsage examples', 'color: blue;');
-
-    for (var i = 0; i < examples.length; i++) {
-      console.log(examples[i].code);
-      if (i != examples.length - 1) {
-        console.log('-------------------------------');
-      }
-    }
-
-    console.groupEnd();
-  }
-}
-
-function params(method) {
-  var params = method.params;
-  for (var i = 0; i < params.length; i++) {
-    console.log('    ' + method.params[i].name + ': ' + method.params[i].description);
-  }
-}
-
 function hasArgumentsParam(method) {
   var params = method.params;
   for (var i = 0; i < params.length; i++) {
@@ -826,5 +791,18 @@ var highlightjs = {
   },
   'hljs-value': {
     color: '#e7635f'
+  }
+};
+
+var defaultStyles = {
+  warning: {
+    background: 'orange'
+  },
+  error: {
+    background: 'red',
+    color: 'white'
+  },
+  info: {
+    background: 'yellow'
   }
 };

--- a/lib/blocks/jsdebug.js
+++ b/lib/blocks/jsdebug.js
@@ -20,6 +20,9 @@ blocks.debug = {
   addType: function (name, checkCallback) {
     customTypes[name.toLowerCase()] = checkCallback;
   },
+  available: function () {
+    return blocks.debug.enabled && !blocks.debug.executing && blocks.debug.paused === 0;
+  },
   paused: 0,
   checkArgs: debugFunc(function (method, args, options) {
     if (!blocks.debug.enabled) {

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -27,7 +27,6 @@
 
   "globals": {
     "blocks": true,
-    "define": true,
-    "__DEBUG_METHOD": true
+    "define": true
   }
 }

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -27,6 +27,7 @@
 
   "globals": {
     "blocks": true,
-    "define": true
+    "define": true,
+    "__DEBUG_METHOD": true
   }
 }

--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -264,7 +264,7 @@ define([
 
       if (this._started) {
         // @if DEBUG
-        blocks.debug.throwMessage('Views can not be constructed / added after the application has been started. Try to add your views sync.', __DEBUG_METHOD, 'Error');
+        blocks.debug.throwMessage('Views can not be constructed / added after the application has been started. Try to add your views synchronous before document.readyState is "complete".', __DEBUG_METHOD, 'Error');
         // @endif
         return;
       }

--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -261,6 +261,14 @@ define([
       if (arguments.length == 1) {
         return this._views[name];
       }
+
+      if (this._started) {
+        // @if DEBUG
+        blocks.debug.throwMessage('Views can not be constructed / added after the application has been started. Try to add your views sync.', __DEBUG_METHOD, 'Error');
+        // @endif
+        return;
+      }
+
       if (blocks.isString(prototype)) {
         this._viewPrototypes[prototype] = this._createView(nestedViewPrototype);
         nestedViewPrototype.options.parentView = name;

--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -263,9 +263,7 @@ define([
       }
 
       if (this._started) {
-        // @if DEBUG
-        blocks.debug.throwMessage('Views can not be constructed / added after the application has been started. Try to add your views synchronous before document.readyState is "complete".', __DEBUG_METHOD, 'Error');
-        // @endif
+        // @debugMessage('Views can not be constructed / added after the application has been started. Try to add your views synchronous before document.readyState is "complete".', Error);
         return;
       }
 

--- a/src/query/DomQuery.js
+++ b/src/query/DomQuery.js
@@ -216,7 +216,9 @@ define([
 
         if (VirtualElement.Is(element)) {
           if (VirtualComment.Is(element) && !method.supportsComments) {
-            // TODO: Should throw debug message
+            // @if DEBUG
+            blocks.debug.throwMessage('data-query ' + methods[i].name + ' does not support to be executed as on a comment.', blocks.debug.queries[methods[i].name], 'Error');
+            // @endif
             continue;
           }
 

--- a/src/query/Expression.js
+++ b/src/query/Expression.js
@@ -9,7 +9,7 @@ define([
     Html: 0,
     ValueOnly: 2,
     NodeWise: 4,
-    
+
     Create: function (text, attributeName, element) {
       var index = -1;
       var endIndex = 0;
@@ -55,7 +55,7 @@ define([
 
       character = text.substring(endIndex);
       if (character) {
-        result.push({ 
+        result.push({
           value: character
         });
       }
@@ -95,7 +95,7 @@ define([
           if ((expression.nodeLength - lastNodeIndex) == 2) {
             value[expression.nodeLength - 2] = null;
           }
-          value[expression.nodeLength - 1] = tempValue; 
+          value[expression.nodeLength - 1] = tempValue;
         } else {
           value = Expression.Execute(context, elementData, expression[0], expression, type);
         }
@@ -103,7 +103,7 @@ define([
         while (++index < length) {
           lastNodeIndex = expression.nodeLength;
           chunk = expression[index];
-          
+
           if (chunk.value) {
             if (type !== Expression.ValueOnly && expression.nodeLength === 0) {
               expression.nodeLength++;
@@ -121,7 +121,7 @@ define([
           } else {
             value +=  tempValue;
           }
-        }  
+        }
       }
 
       expression.lastResult = value;
@@ -142,7 +142,7 @@ define([
       // jshint -W054
       // Disable JSHint error: The Function constructor is a form of eval
       func = parameterQueryCache[expression] = parameterQueryCache[expression] ||
-        new Function('c', 'with(c){with($this){ return ' + expression + '}}');
+        new Function('c', 'with(c){with($this){ return ' + expression + '}}'/*@if DEBUG */ + '//# sourceURL=' + encodeURI(entireExpression.text)/* @endif */);
 
       Observer.startObserving();
 

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -369,9 +369,7 @@ define([
           array = blocks.unwrap(array);
 
           if (!blocks.isArray(array) && !!array) {
-            //@if DEBUG
-            blocks.debug.throwMessage('Array-Observables can not be reseted to a non array type! Reset got aborted.', __DEBUG_METHOD, 'Warning');
-            //@endif
+          //@debugMessage('Array-Observables can not be reseted to a non array type! Reset got aborted.', Warning);
             return;
           }
 

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -37,9 +37,9 @@ define([
       } else if (!blocks.equals(value, currentValue, false) && Events.trigger(observable, 'changing', value, currentValue) !== false) {
         observable.update = blocks.noop;
         if (!observable._dependencyType) {
-          if (blocks.isArray(currentValue) && blocks.isArray(value) && observable.reset) {
+          if (blocks.isArray(currentValue) && (blocks.isArray(value) || !value) && observable.reset) {
             observable.reset(value);
-          } else {
+          } else if (!blocks.isArray(currentValue) && !observable.reset) {
             observable.__value__ = value;
           }
         } else if (observable._dependencyType == 2) {
@@ -367,6 +367,13 @@ define([
           }
 
           array = blocks.unwrap(array);
+
+          if (!blocks.isArray(array) && !!array) {
+            //@if DEBUG
+            blocks.debug.throwMessage('Array-Observables can not be reseted to a non array type! Reset got aborted.', __DEBUG_METHOD, 'Warning');
+            //@endif
+            return;
+          }
 
           var current = this.__value__;
           var chunkManager = this._chunkManager;


### PR DESCRIPTION
Added a ``blocks.debug.throwMessage(Message: String, [method:object], [level: String])`` function.
I don't like that we need to insert the 'method' object manualy if we wan't it to print usage.
Therefore the debug grunt tasks now inlines the Method object to a local variable ```__DEBUG_METHOD``.
I also don't like that because I had to add it to the .jshintrc, but I think it should fit until i come up with a better way (unless you have a better idea).

Also implemented that for failing async view initialization:
![view-async](https://cloud.githubusercontent.com/assets/5108989/18293049/cdea420e-7490-11e6-95d9-6fb33cecb167.PNG)



Array-observables that get reset with a non-nullish and non-array type: closes #116
![array-reset](https://cloud.githubusercontent.com/assets/5108989/18293053/d387d00a-7490-11e6-8ca8-438430f65be8.PNG)


And the usage of non comment-able data-queries on comments:
![comment-queries](https://cloud.githubusercontent.com/assets/5108989/18292900/190f6ecc-7490-11e6-817d-8c0730b92044.PNG)

Also if you ever tried to add a brakepint to an expression you know that it's not that easy...
Now it is (at least in the debug build):
That's a gif showing the initial expressions of the shopping example:
![expression-debugging](https://cloud.githubusercontent.com/assets/5108989/18292918/38963de8-7490-11e6-9e40-834be1d31861.gif)

Edit: Forgot to mention above, but the ``throwMessage``-function will print a stack-trace if the ``method`` argument isn't supplied. Should help in most cases to understand where a message might be comming from.
