### PR TITLE
Travis releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6.9.4"
 before_install: npm install -g grunt-cli
 before_script:
   - grunt compile
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+after_success:
+  - grunt publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,9 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 after_success:
   - grunt publish
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/build/init.js
+++ b/build/init.js
@@ -102,5 +102,6 @@ module.exports = function (grunt) {
   grunt.registerTask('compile', ['build', 'combine', 'preprocess', 'debug', 'build-tests-definitions']);
   grunt.registerTask('live-compile', ['compile', 'watch:compile']);
   grunt.registerTask('full-build', ['jshint', 'compile', 'uglify', 'test', 'npm', 'bower']);
+  grunt.registerTask('build-only', ['jshint', 'compile', 'uglify', 'npm', 'bower']);
   grunt.registerTask('default', []);
 };

--- a/build/publish/GetClosedIssuesAndMergedPRs.graphql
+++ b/build/publish/GetClosedIssuesAndMergedPRs.graphql
@@ -1,0 +1,67 @@
+query ($owner: String!, $repo: String!, $afterIssues: String, $afterPRs: String, $includePRs: Boolean!, $includeIssues: Boolean!) {
+  repository(owner: $owner, name: $repo) {
+    ...issues @include(if: $includeIssues)
+    ...prs @include(if: $includePRs)
+    parent {
+      ...issues @include(if: $includeIssues)
+      ...prs @include(if: $includePRs)
+    }
+  }
+}
+
+fragment issues on Repository {
+  issues(first: 100, after: $afterIssues, states: [CLOSED]) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      number
+      url
+      title
+      timeline(first: 100) {
+        nodes {
+          ... on ReferencedEvent {
+            commit {
+              oid
+            }
+          }
+          ... on ClosedEvent {
+            closeCommit: commit {
+              oid
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment prs on Repository {
+  pullRequests(first: 100, after: $afterPRs, states: [MERGED]) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      title
+      url
+      number
+      timeline(first: 100) {
+        nodes {
+          ... on MergedEvent {
+            commit {
+              oid
+            }
+          }
+        }
+      }
+     # unfortunatly seems to be buggy in the alpha of github graphql
+     # sometime "MERGED" PRs have a mergeCommit and sometimes not
+     # while they are having a "MergedEvent" timeline
+     # mergeCommit {
+     #   oid
+     # }
+    }
+  }
+}

--- a/build/publish/GetMasterCommits.graphql
+++ b/build/publish/GetMasterCommits.graphql
@@ -1,0 +1,45 @@
+query ($owner: String!, $repo: String!, $after: String, $includeLastRelease: Boolean!) {
+	repository(owner: $owner, name: $repo) {
+		...commits
+		...lastRelease @include(if:$includeLastRelease)
+	    # for some reason releases aren't queryable on forked repos if they weren't published on the fork first
+	    # so include the parent in case the repo doesn't have a last release
+	    parent @include(if: $includeLastRelease) {
+			...lastRelease
+	    }
+	}
+}
+
+fragment commits on Repository {
+	ref(qualifiedName: "refs/heads/master") {
+		target {
+			... on Commit {
+				history(first: 100, after: $after) {
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+					nodes {
+						url
+						messageHeadline
+						oid
+					}
+				}
+			}
+		}
+	}
+}
+
+fragment lastRelease on Repository {
+    releases(last: 1) {
+    	nodes {
+    	 	description
+    	 	tag {
+    	    	name
+    	    	target {
+    	    	  oid
+    	    	}
+	 		}
+ 		}
+	}
+}

--- a/build/publish/github-graphql.js
+++ b/build/publish/github-graphql.js
@@ -1,0 +1,165 @@
+var fetch = require('node-fetch');
+var fs = require('fs');
+var path = require('path');
+
+var files = {};
+
+function readFileForMethod(method) {
+	return new Promise(function (resolve, reject) {
+		if (files[method]) {
+			return setTimeout(resolve.bind(null, files[method]));
+		}
+		fs.readFile(path.resolve(__dirname, method + '.graphql'), function (err, file) {
+			if (err) {
+				return reject(err);
+			}
+			files[method] = file.toString().replace('\n', '');
+			resolve(files[method]);
+		});
+	});
+}
+
+function queryGraphQL (method, vars, key) {
+	return readFileForMethod(method).then(function (query) {
+		var body = JSON.stringify({query: query, variables: vars});
+		return fetch('https://api.github.com/graphql', {
+			method: 'POST',
+			headers: {
+				Authorization: 'bearer ' + key
+			},
+			body: body
+		}).then(res => res.json()).then(function (result) {
+			if (result.errors && result.errors.length > 0) {
+				result.errors.forEach(console.error);
+				throw new Error(result.error[0]);
+			}
+			return result;
+		});
+	});
+}
+
+function hasProperties(obj) {
+	for (var key in obj) {
+		return true;
+	}
+	return false;
+}
+
+function GithubGraphQLWrapper (key, owner, repo) {
+	this._key = key;
+	this._repo = repo;
+	this._owner = owner;
+	this._commits = [];
+	this._issues = [];
+	this._mergedPRs = [];
+	this._closedIssues = [];
+	this._lastRelease = null;
+	this._commitAfterRef = null;
+	this._reachedLastIssue = false;
+	this._reachedLastPr = false;
+	this._afterPRRef = null;
+	this._afterIssueRef = null;
+}
+
+GithubGraphQLWrapper.prototype = {
+	constructor: GithubGraphQLWrapper,
+	fetchLastGithubRelease: function fetchLastGithubRelease () {
+		return queryGraphQL('GetMasterCommits', {
+			repo: this._repo,
+			owner: this._owner,
+			includeLastRelease: true,
+			after: this._commitAfterRef
+		}, this._key).then(result => {
+			var data = result.data.repository;
+			var parentRelease = data.parent && data.parent.releases.nodes.length && data.parent.releases.nodes[0];
+			var lastRelease = data.releases.nodes.length > 0 ? data.releases.nodes[0] : parentRelease;
+			var history = data.ref.target.history;
+			this._lastRelease = lastRelease;
+			this._commits = this._commits.concat(history.nodes);
+			this._commitAfterRef = history.pageInfo.endCursor;
+			return this;
+		});
+	},
+	fetchCommitsToLastRelease: function () {
+		return queryGraphQL('GetMasterCommits', {
+			repo: this._repo,
+			owner: this._owner,
+			includeLastRelease: false,
+			after: this._commitAfterRef
+		}, this._key).then(result => {
+			var data = result.data.repository;
+			var history = data.ref.target.history;
+			this._commitAfterRef = data.ref.target.history.pageInfo.endCursor;
+			this._commits = this._commits.concat(data.ref.target.history.nodes);
+			var commitOids = this._commits.map(c => c.oid);
+			if (commitOids.indexOf(this._lastRelease.tag.target.oid) == -1 && history.pageInfo.hasNextPage) {
+				return this.fetchCommitsToLastRelease();
+			}
+			this._commits.splice(commitOids.indexOf(this._lastRelease.tag.target.oid));
+			return this;
+		});
+	},
+	fetchPRsAndIssues: function () {
+		return queryGraphQL('GetClosedIssuesAndMergedPRs', {
+			repo: this._repo,
+			owner: this._owner,
+			includePRs: !this._reachedLastPr,
+			includeIssues: !this._reachedLastIssue,
+			afterIssues: this._afterIssueRef,
+			afterPRs: this._afterPRRef,
+		}, this._key).then(result => {
+			var repository = result.data.repository;
+			var parent = repository.parent;
+			var parentIssues = parent && parent.issues && parent.issues.nodes.length && parent.issues;
+			var localIssues = repository.issues && repository.issues.nodes.length && repository.issues;
+			var issues = localIssues || parentIssues;
+			var parentPRs = parent && parent.pullRequests && parent.pullRequests.nodes.length && parent.pullRequests;
+			var localPRs = repository.pullRequests && repository.pullRequests.nodes.length && repository.pullRequests;
+			var prs = localPRs || parentPRs;
+			if (issues) {
+				this._reachedLastIssue = !issues.pageInfo.hasNextPage;
+				this._afterIssueRef = issues.pageInfo.endCursor;
+				this._closedIssues = this._closedIssues.concat(issues.nodes);
+			}
+
+			if (prs) {
+				this._reachedLastPr = !prs.pageInfo.hasNextPage;
+				this._afterPRRef = prs.pageInfo.endCursor;
+				this._mergedPRs = this._mergedPRs.concat(prs.nodes);
+			}
+			if (!this._reachedLastPr && !this._reachedLastIssue) {
+				return this.fetchPRsAndIssues();
+			}
+		}).then(() => {
+			this._closedIssues = this._closedIssues.map(issue => {
+				issue.timeline = issue.timeline.nodes.filter(hasProperties);
+				return issue;
+			}).filter(issue => issue.timeline.length > 0);
+			this._mergedPRs.map(pr => {
+				pr.timeline = pr.timeline.nodes.filter(hasProperties);
+				return pr;
+			}).filter(pr => pr.timeline.length > 0);
+			return this;
+		});
+	},
+	getLastRelease: function () {
+		return this._lastRelease;
+	},
+	getMergedPRs: function () {
+		return this._mergedPRs;
+	},
+	getCommits: function () {
+		return this._commits;
+	},
+	getClosedIssues: function () {
+		return this._closedIssues;
+	},
+	getOwner: function () {
+		return this._owner;
+	},
+	getRepo: function () {
+		return this._repo;
+	}
+};
+
+module.exports = GithubGraphQLWrapper;

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -284,11 +284,12 @@ module.exports = function (grunt) {
        grunt.task.requires('build-only');
        var done = this.async();
        commitRelease()
-           .then(publishRelease)
-           .then(function () {
+       		.then(publishNpm)
+        	.then(publishRelease)
+           	.then(function () {
                    grunt.log.writeln('Done publishing.');
                    done();
-           }).catch(function (e) {
+           	}).catch(function (e) {
                    grunt.log.error(e);
                    grunt.log.error(e.stack());
                    done(false);

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -256,7 +256,7 @@ module.exports = function (grunt) {
 						Authorization: `token ${gitKey}`,
 					},
 					body: JSON.stringify({
-						prerelease: /rc,alpha,beta/i.test(grunt.config.data.version),
+						prerelease: /rc|alpha|beta/i.test(grunt.config.data.version),
 						name: grunt.config.data.version,
 						tag_name: grunt.config.data.version,
 						body: releaseNotes

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -176,6 +176,22 @@ module.exports = function (grunt) {
 						}
 					}
 				);
+			}).then(function () {
+				grunt.log.writeln('Pushed to git.');
+			});
+	}
+
+	function publishNpm () {
+		var cwd = process.cwd();
+		process.chdir(require('path').join(cwd, 'dist/npm'));
+		grunt.log.writeln('Publishing to NPM.');
+		return npmUtils.setAuthToken()
+			.then(function () {
+				return npmUtils.publish();
+			})
+			.then(function () {
+				process.chdir(cwd);
+				grunt.log.writeln('Published to npm.');
 			});
 	}
 
@@ -184,6 +200,7 @@ module.exports = function (grunt) {
 		var done = this.async();
 		commitRelease()
 			.then(function () {
+				grunt.log.writeln('Done publishing.');
 				done();
 			}).catch(function (e) {
 				grunt.log.error(e);

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -158,7 +158,10 @@ module.exports = function (grunt) {
 				return repository.createCommit('HEAD', author, author, '[ci skip] Build Version ' + version, oid, [parent]);
 			}).then(function (id) {
 				grunt.log.writeln('Created commit ' + id + 'for ' + version);
-				return Git.Tag.create(repository, version, id, author, 'Release v'+version, 0); // 0 = don't force tag creation
+				return Git.Object.lookup(repository, id, Git.Object.TYPE.COMMIT);
+			})
+			.then(function (object)  {
+				return Git.Tag.create(repository, version, object, author, 'Release v'+version, 0); // 0 = don't force tag creation
 			}).then(function () {
 				grunt.log.writeln('Created tag ' + version);
 				return repository.getRemote('origin');

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -135,7 +135,7 @@ module.exports = function (grunt) {
 		var repository;
 		var index;
 		var oid;
-		var author = Git.Signature.create(gitUser, gitEmail, Date.now(), 0);
+		var author = Git.Signature.now(gitUser, gitEmail);
 		return Git.Repository.open('.')
 			.then(function (repo) {
 				repository = repo;
@@ -157,7 +157,7 @@ module.exports = function (grunt) {
 			}).then(function (parent) {
 				return repository.createCommit('HEAD', author, author, '[ci skip] Build Version ' + version, oid, [parent]);
 			}).then(function (id) {
-				return Git.Tag.create(repository, version, id, author, 'Release v'+version);
+				return Git.Tag.create(repository, version, id, author, 'Release v'+version, 0); // 0 = don't force tag creation
 			}).then(function () {
 				return repository.getRemote('origin');
 			})

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -157,8 +157,10 @@ module.exports = function (grunt) {
 			}).then(function (parent) {
 				return repository.createCommit('HEAD', author, author, '[ci skip] Build Version ' + version, oid, [parent]);
 			}).then(function (id) {
+				grunt.log.writeln('Created commit ' + id + 'for ' + version);
 				return Git.Tag.create(repository, version, id, author, 'Release v'+version, 0); // 0 = don't force tag creation
 			}).then(function () {
+				grunt.log.writeln('Created tag ' + version);
 				return repository.getRemote('origin');
 			})
 			.then(function (remote) {
@@ -204,6 +206,7 @@ module.exports = function (grunt) {
 				done();
 			}).catch(function (e) {
 				grunt.log.error(e);
+				grunt.log.error(e.stack());
 				done(false);
 			});
 	});

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -1,0 +1,160 @@
+module.exports = function (grunt) {
+	var Git = require('nodegit');
+	var npmUtils = require('npm-utils');
+	var gitUser = process.env.GIT_USER;
+	var gitPassword = process.env.GIT_PASSWORD;
+	var gitEmail = process.env.GIT_EMAIL;
+
+	function getMasterCommit (repo) {
+		return repo.getMasterCommit();
+	}
+
+	function getPatches(commit) {
+		return commit.getDiff().then(function (diffs) {
+			return Promise.all(diffs.map(function (diff) {
+				return diff.patches();
+			})).then(function (patchesArray) {
+				var patches = [];
+				for (var i in patchesArray) {
+					patches.splice.apply(patches, [0, 0].concat(patchesArray[i]));
+				}
+				return patches;
+			});
+		});
+	}
+
+	function findPackageJsonPatch(patches) {
+		var patch;
+		for (var i in patches) {
+			patch = patches[i];
+			if (patch.isModified()) {
+				if (patch.newFile().path() == 'package.json') {
+					return patch;
+				}
+			}
+		}
+		throw new Error('No change in package.json');
+	}
+
+	function dontContainsTag (repo, tagName) {
+		return Git.Tag.list(repo).then(function (tags) {
+			return tags.map(function (tag) {
+				return tag.name();
+			}).indexOf(tagName) == -1;
+		});
+	}
+
+	function hasVersionChange (patch, repo) {
+		var oldFile = patch.oldFile();
+		var newFile = patch.newFile();
+		var newContent;
+		var oldContent;
+		return Promise.all([
+			repo.getBlob(newFile.id()),
+			repo.getBlob(oldFile.id())
+		]).then(function (blobs) {
+			newContent = JSON.parse(blobs[0].toString('utf-8'));
+			oldContent = JSON.parse(blobs[1].toString('utf-8'));
+			if (newContent.version != oldContent.version) {
+				return true;
+			}
+			return false;
+		}).then(function (versionChanged) {
+			if (!versionChanged) {
+				return false;
+			} else {
+				return dontContainsTag(repo, newContent.version);
+			}
+		});
+	}
+
+	grunt.registerTask('publish', function() {
+		if (!gitUser || !gitPassword || !gitEmail) {
+			grunt.log.error('Missing login data for github. Make sure GIT_USER, GIT_EMAIL and GIT_PASSWORD are set in the environment.');
+			return;
+		}
+		var done = this.async();
+
+		var repository;
+		Git.Repository.open('.')
+			.then(function (repo) {
+				repository = repo;
+				return repo;
+			})
+			.then(getMasterCommit)
+			.then(getPatches)
+			.then(findPackageJsonPatch)
+			.then(function (patch) {
+				return hasVersionChange(patch, repository);
+			})
+			.then(function (versionChanged) {
+				if (versionChanged) {
+					grunt.log.writeln('Package version has changed. Build will be published.');
+					grunt.task.run(['build-only', 'publish-post-build']);
+					done();
+				} else {
+					grunt.log.writeln('Version has not changed.');
+					done();
+				}
+			}).catch(function (e) {
+				if (e.message == 'No change in package.json') {
+					grunt.log.writeln(e.message);
+					done();
+				} else {
+					grunt.log.warn(e);
+					done(false);
+				}
+			});
+	});
+	grunt.registerTask('publish-post-build', function () {
+		grunt.task.requires('build-only');
+		var done = this.async();
+		var version = grunt.config.data.version;
+		var repository;
+		var index;
+		var oid;
+		var author = Git.Signature.create(gitUser, gitEmail, Date.now(), 0);
+		Git.Repository.open('.')
+			.then(function (repo) {
+				repository = repo;
+				return repo.refreshIndex();
+			})
+			.then(function (indexRes) {
+				index = indexRes;
+				return index.addAll();
+			}).then(function () {
+				return index.write();
+			}).then(function () {
+				return index.writeTree();
+			}).then(function (oidRes) {
+				oid = oidRes;
+				return Git.Reference.nameToId(repository, 'HEAD');
+			}).then(function (head) {
+				return repository.getCommit(head);
+			}).then(function (parent) {
+				return repository.createCommit('HEAD', author, author, 'Build Version ' + version, oid, [parent]);
+			}).then(function (id) {
+				return repository.createTag(id, version, 'Release v'+version);
+			}).then(function () {
+				return repository.getRemote('origin');
+			})
+			.then(function (remote) {
+				return remote.push(
+					["refs/heads/master:refs/heads/master"],
+					{
+						callbacks: {
+							credentials: function () {
+								return Git.Cred.userpassPlainTextNew(gitUser, gitPassword);
+							}
+						}
+					}
+				);
+			})
+			.then(function () {
+				done();
+			}).catch(function (e) {
+				grunt.log.error(e);
+				done(false);
+			});
+	});
+};

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -144,7 +144,7 @@ module.exports = function (grunt) {
 					{
 						callbacks: {
 							credentials: function () {
-								return Git.Cred.userpassPlainTextNew(gitUser, gitPassword);
+								return Git.Cred.userpassPlaintextNew(gitUser, gitPassword);
 							}
 						}
 					}

--- a/build/tasks/publish.js
+++ b/build/tasks/publish.js
@@ -129,23 +129,25 @@ module.exports = function (grunt) {
 				}
 			});
 	});
-	grunt.registerTask('publish-post-build', function () {
-		grunt.task.requires('build-only');
-		var done = this.async();
+
+	function commitRelease () {
 		var version = grunt.config.data.version;
 		var repository;
 		var index;
 		var oid;
 		var author = Git.Signature.create(gitUser, gitEmail, Date.now(), 0);
-		Git.Repository.open('.')
+		return Git.Repository.open('.')
 			.then(function (repo) {
 				repository = repo;
-				return repo.refreshIndex();
+			})
+			.then(function () {
+				return repository.refreshIndex();
 			})
 			.then(function (indexRes) {
 				index = indexRes;
 				return index.addAll();
-			}).then(function () {
+			})
+			.then(function () {
 				return index.write();
 			}).then(function () {
 				return index.writeTree();
@@ -155,7 +157,7 @@ module.exports = function (grunt) {
 			}).then(function (parent) {
 				return repository.createCommit('HEAD', author, author, '[ci skip] Build Version ' + version, oid, [parent]);
 			}).then(function (id) {
-				return repository.createTag(id, version, 'Release v'+version);
+				return Git.Tag.create(repository, version, id, author, 'Release v'+version);
 			}).then(function () {
 				return repository.getRemote('origin');
 			})
@@ -174,7 +176,13 @@ module.exports = function (grunt) {
 						}
 					}
 				);
-			})
+			});
+	}
+
+	grunt.registerTask('publish-post-build', function () {
+		grunt.task.requires('build-only');
+		var done = this.async();
+		commitRelease()
 			.then(function () {
 				done();
 			}).catch(function (e) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-jquery": "^0.1.1",
+    "nodegit": "^0.16.0",
+    "npm-utils": "^1.11.0",
     "parse5": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "escodegen": "^1.6.1",
     "esprima": "^3.0.0",
     "estraverse": "^4.1.0",
+    "github": "^8.1.1",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "escodegen": "^1.6.1",
     "esprima": "^3.0.0",
     "estraverse": "^4.1.0",
-    "github": "^8.1.1",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^1.0.0",
@@ -34,7 +33,8 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-jquery": "^0.1.1",
-    "nodegit": "^0.16.0",
+    "node-fetch": "^1.6.3",
+    "nodegit": "^0.17.0",
     "npm-utils": "^1.11.0",
     "parse5": "^2.2.1"
   }


### PR DESCRIPTION
With the graphql api it's possible to fetch everything we need.
The api is still early access/alpha and so has some bugs I needed to work arround and some things that don't work as smooth as I hoped. But that's okay.
Because it's an alpha version some things *could* go wrong with a release, but nothing I shouldn't be able to fix within a few minutes. So I guess that's fine.
GraphQL is nicer than normal REST APIs (previously I hit the limit of github api calls) and now it's maybe a couple dozen of calls instead of a couple hundred.
I would like it to have more options to query or to set vars within an query (SQL subselect-ish) but I guess it's a start.

Detection before it tries to publish anything:
- checks if ``GIT_KEY``, ``GIT_USER`` and ``GIT_EMAIL`` are set in the env.
- checks if the package.jsons version property in the project root has been changed in the last commit.
- checks if there is yet a release on github with the same version (prevents errorss if somehow a travis build is triggert twice for one commit).

Github releases work fine. 
It tags, commits and then pushes to the repo.
After that it fetches the issues, prs, build a release log and publishes it with the github release (currently via the REST api the GraphQL API can't create releases (yet)).

With the last commit it also publishes/updates the npm package between pushing the tag&commit and publishing the release.
It's not tested, but it just needs the ``NPM_TOKEN`` env var set and after switching the processes cwd to the dist/npm dir the [npm-utils](https://www.npmjs.com/package/npm-utils) node module does the rest.

[Here](https://github.com/Kanaye/jsblocks/releases/tag/0.3.5-alpha1) the test github release on my jsblocks fork.
And [here](https://travis-ci.org/Kanaye/jsblocks) the tavis log of the build.

The release will be availble on:
- github
- bower
- npm
- jsdelivr (because there bot also fetches github)

Tell me if I missed something.

This add 3 new dev dependencies:
1. node-fetch: just a pure-js dependency, I just like fetch more than the node-api and because it's just a small dependencie I took it
2. npm-utils: a wrapper for the npm cli that also handles auth via env vars.
3. nodegit: that's the heavy one, it requires a  c++ 11 compiler on exotic node versions (for lts and current versions it just downloads binaries on the supported platforms).
It also required me to let travis fetch a current c++ 11 stdlib, makes travis builds a little slower.
If you whish we can move that dependencies to an other package.json and only install them if we need them.
I also updated the nodejs version travis uses to tha last LTS, I think the last LTS is the version we should focus on and also some of the dependencies required a current release.

I also created a JSBlocks-CI [github](https://github.com/JSBlocks-CI) and [npm](https://www.npmjs.com/~jsblocks-ci) user. 
**[edit:]** 
These two have currently the email address: jsblocks-ci@kanaye.net running on my mailserver if you wish we can change that to some other address (e.g. a @jsblocks.com address) otherwise I'm fine with leaving them running on my mail-server.
**[/edit]**
Once these two have access and I added the env-vars to travis we should be ready to go.

Tell me what you think.