### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/mvc/Application.js
+++ b/src/mvc/Application.js
@@ -257,7 +257,7 @@ define([
      */
     View: function (name, prototype, nestedViewPrototype) {
       // TODO: Validate prototype by checking if a property does not override a proto method
-      // if the prototype[propertyName] Type eqals the proto[propertyName] Type do not throw error
+      // if the prototype[propertyName] Type equals the proto[propertyName] Type do not throw error
       if (arguments.length == 1) {
         return this._views[name];
       }

--- a/src/mvc/Model.js
+++ b/src/mvc/Model.js
@@ -11,7 +11,7 @@ define([
    */
   function Model(application, prototype, dataItem, collection) {
     var _this = this;
-    // deep clone dataItem, otherwise we don't clone obervables nested in Models
+    // deep clone dataItem, otherwise we don't clone observables nested in Models
     dataItem = blocks.clone(dataItem, true);
     this._application = application;
     this._prototype = prototype;

--- a/src/mvc/queries.js
+++ b/src/mvc/queries.js
@@ -11,7 +11,7 @@
     /**
      * Associates the element with the particular view and creates a $view context property.
      * The View will be automatically hidden and shown if the view have routing. The visibility
-     * of the View could be also controled using the isActive observable property
+     * of the View could be also controlled using the isActive observable property
      *
      * @memberof blocks.queries
      * @param {View} view - The view to associate with the current element
@@ -49,7 +49,7 @@
           if (view._html) {
             blocks.queries.template.preprocess.call(this, domQuery, view._html, view);
           }
-          // Quotes are used because of IE8 and below. It failes with 'Expected idenfitier'
+          // Quotes are used because of IE8 and below. It fails with 'Expected idenfitier'
           //queries['with'].preprocess.call(this, domQuery, view, '$view');
           //queries.define.preprocess.call(this, domQuery, view._name, view);
         }
@@ -60,7 +60,7 @@
       update: function (domQuery, view) {
         if (view.isActive()) {
           if (view._html) {
-            // Quotes are used because of IE8 and below. It failes with 'Expected idenfitier'
+            // Quotes are used because of IE8 and below. It fails with 'Expected idenfitier'
             queries['with'].preprocess.call(this, domQuery, view, '$view');
 
             this.innerHTML = view._html;

--- a/src/query/methods.js
+++ b/src/query/methods.js
@@ -101,7 +101,7 @@ define([
   };
 
   /**
-   * Gets the associated dataItem for a particlar element. Searches all parents until it finds the context
+   * Gets the associated dataItem for a particular element. Searches all parents until it finds the context
    *
    * @memberof blocks
    * @param {(HTMLElement|blocks.VirtualElement)} element - The element from which to search for a dataItem
@@ -182,7 +182,7 @@ define([
    * @param  {string} expression The expression to execute.
    * @param  {Object} context    The context to exute the expression on.
    *                             The context for an element can be get via block.context().
-   * @param  {Object} [options]  An optional options objecz.
+   * @param  {Object} [options]  An optional options object.
    * @param  {bool}   [options.raw] If true the function returns an array with the raw value. Default: false
    *
    * @returns {string|Object[]}]  Returns the result of the expressions as a string.

--- a/src/query/observable.js
+++ b/src/query/observable.js
@@ -18,7 +18,7 @@ define([
 
   /**
   * @namespace blocks.observable
-  * @param {*} initialValue - The inital value of the observable. This value will also specify the functions the observable inherits (e.g. array specific functions). Do not change types of observables later.
+  * @param {*} initialValue - The initial value of the observable. This value will also specify the functions the observable inherits (e.g. array specific functions). Do not change types of observables later.
   * @param {*} [context] - The context the observable will be bound to.
   * @returns {blocks.observable}
   */
@@ -946,7 +946,7 @@ define([
           var updateCount = value.length - addCount;
 
           blocks.observable.fn.base.update.apply(this);
-          // Update 'each'-queries for dependencie obseravbles if the value is an array
+          // Update 'each'-queries for dependency observables if the value is an array
           if (blocks.isArray(value)) {
             chunkManager.each(function(domElement, virtualElement) {
               var domQuery = blocks.domQuery(domElement);

--- a/test/spec/query/attribute-queries.js
+++ b/test/spec/query/attribute-queries.js
@@ -306,7 +306,7 @@
         expect($('#testElement')).toHaveHtml('HTML');
       });
 
-      // DEPRICATED!
+      // Deprecated!
       // it('shouldnt replace any existing html', function () {
       //   $('#testElement').html('already existing html');
       //
@@ -367,7 +367,7 @@
         expect($('#testElement')).toHaveHtml('HTML');
       });
 
-      // DEPRICATED:
+      // Deprecated:
       // it('shouldnt replace any existing html', function () {
       //   $('#testElement').html('already existing html');
       //
@@ -511,7 +511,7 @@
         });
       });
 
-      // !!DEPRICATED!!
+      // !!Deprecated!!
       // it('should remove css styles from an object to an element', function () {
       //   var zIndex = blocks.observable(3);
       //   $('#testElement').css('visibility', 'hidden');
@@ -787,7 +787,7 @@
         expect($('#testElement')).toHaveAttr('data-custom', 'second');
       });
 
-      // The condition argument have been depricated
+      // The condition argument have been deprecated
       //
       // it('should remove attributes from an object to an element', function () {
       //   var shouldSetAttributes = blocks.observable(false);
@@ -1432,7 +1432,7 @@
         expect($('#testElement')).toHaveCss({ width: '130px' });
       });
 
-      // !!DEPRICATED!!
+      // !!Deprecated!!
       // it('should remove the width from an element', function () {
       //   var originalWidth = $('#testElement').width();
       //

--- a/test/spec/query/contexts.js
+++ b/test/spec/query/contexts.js
@@ -440,7 +440,7 @@
       });
     });
 
-    // The each(array) is hard coded and every call to query must contain an array property. For convinience there is a getArray function
+    // The each(array) is hard coded and every call to query must contain an array property. For convenience there is a getArray function
     // query({
     //   array: getArray()
     //})


### PR DESCRIPTION
There are small typos in:
- src/mvc/Application.js
- src/mvc/Model.js
- src/mvc/queries.js
- src/query/methods.js
- src/query/observable.js
- test/spec/query/attribute-queries.js
- test/spec/query/contexts.js

Fixes:
- Should read `fails` rather than `failes`.
- Should read `particular` rather than `particlar`.
- Should read `observables` rather than `obseravbles`.
- Should read `observables` rather than `obervables`.
- Should read `object` rather than `objecz`.
- Should read `initial` rather than `inital`.
- Should read `equals` rather than `eqals`.
- Should read `deprecated` rather than `depricated`.
- Should read `dependency` rather than `dependencie`.
- Should read `convenience` rather than `convinience`.
- Should read `controlled` rather than `controled`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md